### PR TITLE
Confirm project path if cwd is not a node project.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ const getArgOptions = (argv: string[]): string[] => {
   return options;
 };
 
-const confirmRootDir = async (rootDir: string): Promise<string> => {
+export const confirmRootDir = async (rootDir: string): Promise<string> => {
   Logger.error(`${colors.yellow('Warning:')} Current working directory is not a node project and contains some files.`);
 
   const answers = await prompt([

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,8 @@ export const symbols = () => {
   };
 };
 
+export const isNodeProject = (rootDir: string): boolean => fs.existsSync(path.join(rootDir, 'package.json'));
+
 export const copy = (src: string, dest: string, excludeDir: string[] = []): void => {
   const stat = fs.statSync(src);
   if (stat.isDirectory()) {


### PR DESCRIPTION
If the user is using `npm init nightwatch` and the current working directory is not a node project but contains some files, to avoid initializing the Nightwatch project in the wrong folder by mistake, this PR adds a check and confirms from the user if the current directory is actually the expected root of the Nightwatch project to be initialised.