### PR TITLE
Fix tsc: command not found error.

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -267,7 +267,7 @@ export class NightwatchInit {
 
     // Generate a new tsconfig.json file if not already present.
     if (!fs.existsSync(tsConfigPath)) {
-      execSync('tsc --init', {
+      execSync('npx tsc --init', {
         stdio: 'inherit',
         cwd: this.rootDir
       });

--- a/tests/e2e_tests/init.js
+++ b/tests/e2e_tests/init.js
@@ -639,7 +639,7 @@ describe('e2e tests for init', () => {
     assert.strictEqual(commandsExecuted[1], 'npm install typescript --save-dev');
     assert.strictEqual(commandsExecuted[2], 'npm install @types/nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[3], 'npm install ts-node --save-dev');
-    assert.strictEqual(commandsExecuted[4], 'tsc --init');
+    assert.strictEqual(commandsExecuted[4], 'npx tsc --init');
 
     // Test examples copied
     const examplesPath = path.join(rootDir, answers.examplesLocation);
@@ -807,7 +807,7 @@ describe('e2e tests for init', () => {
     assert.strictEqual(commandsExecuted[2], 'npm install @types/nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[3], 'npm install ts-node --save-dev');
     assert.strictEqual(commandsExecuted[4], 'npm install @nightwatch/selenium-server --save-dev');
-    assert.strictEqual(commandsExecuted[5], 'tsc --init');
+    assert.strictEqual(commandsExecuted[5], 'npx tsc --init');
     assert.strictEqual(commandsExecuted[6], 'java -version');
     assert.strictEqual(commandsExecuted[7], 'npm install geckodriver --save-dev');
 

--- a/tests/unit_tests/testInit.js
+++ b/tests/unit_tests/testInit.js
@@ -449,7 +449,7 @@ describe('init tests', () => {
       nightwatchInit.setupTypescript();
 
       assert.strictEqual(commandsExecuted.length, 1);
-      assert.strictEqual(commandsExecuted[0], 'tsc --init');
+      assert.strictEqual(commandsExecuted[0], 'npx tsc --init');
 
       assert.strictEqual(nwTsconfigCopied, true);
       assert.strictEqual(nightwatchInit.otherInfo.tsOutDir, '');
@@ -513,7 +513,7 @@ describe('init tests', () => {
       nightwatchInit.setupTypescript();
 
       assert.strictEqual(commandsExecuted.length, 1);
-      assert.strictEqual(commandsExecuted[0], 'tsc --init');
+      assert.strictEqual(commandsExecuted[0], 'npx tsc --init');
 
       assert.strictEqual(nwTsconfigCopied, false);
       assert.strictEqual(nightwatchInit.otherInfo.tsOutDir, '');


### PR DESCRIPTION
This error was occurring when running the tool from outside root dir.

Working fine if executed from inside `new-project`: `npm init nightwatch`.

Not working if execute from outside `new-project`: `npm init nightwatch new-project`.
Error:
```sh
/bin/sh: tsc: command not found
Error: Command failed: tsc --init
    at checkExecSyncError (node:child_process:828:11)
    at execSync (node:child_process:899:15)
    at NightwatchInit.setupTypescript (/Users/priyansh/.npm/_npx/616f4dea4ff90533/node_modules/create-nightwatch-test/dist/init.js:248:42)
    at NightwatchInit.<anonymous> (/Users/priyansh/.npm/_npx/616f4dea4ff90533/node_modules/create-nightwatch-test/dist/init.js:61:22)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/priyansh/.npm/_npx/616f4dea4ff90533/node_modules/create-nightwatch-test/dist/init.js:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  status: 127,
  signal: null,
  output: [ null, null, null ],
  pid: 76412,
  stdout: null,
  stderr: null
}
```