### PR TITLE
Auto-publish package to NPM on new tag push.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to NPM
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm install
+      - name: Publish package on NPM 📦
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "build-to-publish": "tsc --outDir dist",
+    "prepublishOnly": "tsc --outDir dist",
     "create-nightwatch": "tsc && node dev-run.js",
     "test:unit": "npx nightwatch tests/unit_tests",
-    "prepublishOnly": "npm run build-to-publish",
     "test:e2e": "npx nightwatch tests/e2e_tests"
   },
   "keywords": [],


### PR DESCRIPTION
Fixes: #28 

During auto-publish on GitHub Action, the `ts` files are transpiled to `dist` directory, which will be pushed to NPM and used in our users' systems.

Tested this workflow by creating a new package `create-nightwatch-test` using another id. Test workflow run can be found [here](https://github.com/garg3133/create-nightwatch/actions/runs/3062616067/jobs/4943790994).

**Note:** We also need to generate and save the NPM Access Token as a Repository Secret in this repository, like shown [here](https://dev.to/astagi/publish-to-npm-using-github-actions-23fn).