### PR TITLE
Make it easier to publish package from local.

### DIFF
--- a/dev-run.js
+++ b/dev-run.js
@@ -1,0 +1,1 @@
+require('./lib/index.js').run();

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('./lib/index.js').run();
+require('./dist/index.js').run();

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "create-nightwatch": "tsc && node index.js",
-    "prepublish": "npm run build",
+    "build-to-publish": "tsc --outDir dist",
+    "create-nightwatch": "tsc && node dev-run.js",
     "test:unit": "npx nightwatch tests/unit_tests",
     "test:e2e": "npx nightwatch tests/e2e_tests"
   },


### PR DESCRIPTION
After this, during development, all the `ts` files will be transpiled to `lib` directory as before. But while publishing the package from local, `npm run build-to-publish` can be run which will transpile all the `ts` files into a separate `dist` directory, which will be pushed to NPM (as it is not included in `.gitignore`) and used in our users' systems.

`lib` directory --> for development purposes.
`dist` directory --> for production purposes.
