### PR TITLE
Github test was failing, title changes often, switched to a contains …

### DIFF
--- a/assets/ts-examples/github.ts
+++ b/assets/ts-examples/github.ts
@@ -4,7 +4,7 @@ const home: NightwatchTests = {
   'Github Title test': () => {
     browser
       .url('https://github.com')
-      .assert.titleContains('GitHub: ');
+      .assert.titleContains('GitHub');
   },
 
   'Github search for nightwatch repository': () => {

--- a/assets/ts-examples/github.ts
+++ b/assets/ts-examples/github.ts
@@ -4,7 +4,7 @@ const home: NightwatchTests = {
   'Github Title test': () => {
     browser
       .url('https://github.com')
-      .assert.titleEquals('GitHub: Where the world builds software · GitHub');
+      .assert.titleContains('GitHub: ');
   },
 
   'Github search for nightwatch repository': () => {


### PR DESCRIPTION
The GitHub page title changes often. Updating the test to have a less-risky assertion using titleContains