### PR TITLE
Refine prompts and output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ lib/
 .idea
 tests_output/
 test_output/
+nightwatch.conf.js
+nightwatch/
 chromedriver-mobile/
 logs/

--- a/assets/templates/login.js
+++ b/assets/templates/login.js
@@ -2,14 +2,13 @@
  * To learn more about the describe interface, refer to the following link :
  * https://nightwatchjs.org/guide/writing-tests/test-syntax.html
  */
-describe('The Login Page', () => {
+describe('The Login Page', function () {
 
   /**
    * This section will always execute before the test suite
    * Read More : https://nightwatchjs.org/guide/writing-tests/using-test-hooks.html#before-beforeeach-after-aftereach
    */
-  before(browser => {
-
+  before(function (browser) {
     /**
      * Navigate to a URL :
      *   - We need to navigate before performing any actions on the page
@@ -117,7 +116,7 @@ describe('The Login Page', () => {
 
 
   /* The following will always execute after the test suite */
-  after(browser => {
+  after(function (browser) {
     // This is used to close the browser's session
     browser.end();
   });

--- a/assets/templates/titleAssertion.js
+++ b/assets/templates/titleAssertion.js
@@ -2,13 +2,13 @@
  * To learn more about the describe interface, refer to the following link:
  * https://nightwatchjs.org/guide/writing-tests/test-syntax.html
  */
-describe('Title Assertion', () => {
+describe('Title Assertion', function() {
     
   /**
    * This section will always execute before the test suite
    * Read More : https://nightwatchjs.org/guide/writing-tests/using-test-hooks.html#before-beforeeach-after-aftereach
    */ 
-  before(browser => {
+  before(function (browser) {
     /**
      * Navigate to a URL :
      *   - We need to navigate before performing any actions on the page
@@ -38,7 +38,7 @@ describe('Title Assertion', () => {
 
 
   /* The following will always execute after the test suite */
-  after(browser => {
+  after(function (browser) {
     // This is used to close the browser's session
     browser.end();
   });

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -1,6 +1,6 @@
 {
   "src_folders": [
-    "tests"
+    "test"
   ],
   "unit_tests_mode": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "ejs": "^3.1.8",
         "inquirer": "^8.2.4",
         "minimist": "^1.2.6",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "bin": {
         "create-nightwatch": "index.js"
@@ -32,9 +32,11 @@
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
         "@typescript-eslint/parser": "^5.27.1",
-        "eslint": "^8.17.0",
+        "chromedriver": "^107.0.3",
+        "eslint": "^8.27.0",
+        "mocha": "^10.1.0",
         "mockery": "^2.1.0",
-        "nightwatch": "^2.1.8",
+        "nightwatch": "^2.5.0",
         "nock": "^13.2.9",
         "typescript": "^4.7.3"
       }
@@ -197,6 +199,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@appium/support/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@appium/types": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.5.0.tgz",
@@ -356,14 +366,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -959,9 +969,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.3.tgz",
       "integrity": "sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/archiver": {
       "version": "5.3.1",
@@ -1272,7 +1280,6 @@
       "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1551,8 +1558,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -2210,13 +2215,11 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "107.0.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-107.0.2.tgz",
-      "integrity": "sha512-EUxGiMo855vyxqUnMciA9dIprwy364rRbdKuKc9fRZ68PSGL0JcvO70c01scYGLfhu9n4KZbM5WXK+dzlmk2cg==",
+      "version": "107.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-107.0.3.tgz",
+      "integrity": "sha512-jmzpZgctCRnhYAn0l/NIjP4vYN3L8GFVbterTrRr2Ly3W5rFMb9H8EKGuM5JCViPKSit8FbE718kZTEt3Yvffg==",
       "dev": true,
       "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
         "axios": "^1.1.3",
@@ -2230,7 +2233,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
@@ -2238,8 +2241,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
       "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -2393,9 +2394,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
       "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/compress-commons": {
       "version": "4.1.1",
@@ -3157,14 +3156,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -3180,14 +3180,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -3429,8 +3429,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -3451,8 +3449,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -4094,8 +4090,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -4251,8 +4245,6 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4364,6 +4356,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -4404,9 +4405,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -4425,8 +4424,6 @@
       "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
       "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "ip-regex": "^4.1.0",
@@ -5106,42 +5103,39 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
+      "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5166,29 +5160,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5235,15 +5206,24 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -5342,9 +5322,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -5368,9 +5348,9 @@
       }
     },
     "node_modules/nightwatch": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.4.2.tgz",
-      "integrity": "sha512-3kDVPT3Na/4yRA2q+/zSTwYUijTmsn+5L4AaqDebWbv1kGHVzv84AFxNIf4hGaCIB79AyhiFnkSj3L065OZZ7w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.5.0.tgz",
+      "integrity": "sha512-Y3TkvOLl/KM/j6pjeOD6CR5beCzjupDjAzFRGt0peumt0HTP2d2d4QydB+VXTxGyO0UJX9OmkusGUnKGZt604Q==",
       "dev": true,
       "dependencies": {
         "@nightwatch/chai": "5.0.2",
@@ -5397,17 +5377,18 @@
         "nightwatch-axe-verbose": "2.0.3",
         "open": "8.4.0",
         "ora": "5.4.1",
-        "selenium-webdriver": "4.3.1",
+        "selenium-webdriver": "4.5.0",
         "semver": "7.3.5",
         "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
+        "untildify": "^4.0.0",
         "uuid": "8.3.2"
       },
       "bin": {
         "nightwatch": "bin/nightwatch"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.0.0"
       },
       "peerDependencies": {
         "@cucumber/cucumber": "*",
@@ -5435,6 +5416,159 @@
         "axe-core": "^4.4.3"
       }
     },
+    "node_modules/nightwatch/node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/nightwatch/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/nightwatch/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nightwatch/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nightwatch/node_modules/mocha": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/nightwatch/node_modules/mocha/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nightwatch/node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nightwatch/node_modules/mocha/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nightwatch/node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nightwatch/node_modules/nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/nightwatch/node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5449,6 +5583,36 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/nightwatch/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/nightwatch/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/nightwatch/node_modules/workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "dev": true
     },
     "node_modules/nock": {
       "version": "13.2.9",
@@ -6289,9 +6453,9 @@
       }
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.3.1.tgz",
-      "integrity": "sha512-TjH/ls1WKRQoFEHcqtn6UtwcLnA3yvx08v9cSSFYvyhp8hJWRtbe9ae2I8uXPisEZ2EaGKKoxBZ4EHv0BJM15g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz",
+      "integrity": "sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==",
       "dev": true,
       "dependencies": {
         "jszip": "^3.10.0",
@@ -6299,7 +6463,7 @@
         "ws": ">=8.7.0"
       },
       "engines": {
-        "node": ">= 10.15.0"
+        "node": ">= 14.20.0"
       }
     },
     "node_modules/selenium-webdriver/node_modules/tmp": {
@@ -6636,8 +6800,6 @@
       "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
       "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4.3.1",
         "is2": "^2.0.6"
@@ -6648,8 +6810,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6942,9 +7102,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7009,9 +7169,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -7036,9 +7196,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -7318,6 +7478,11 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.1.0.tgz",
           "integrity": "sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -7441,14 +7606,14 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/module-importer": {
@@ -7904,9 +8069,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.3.tgz",
       "integrity": "sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@types/archiver": {
       "version": "5.3.1",
@@ -8217,7 +8380,6 @@
       "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -8385,8 +8547,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "debug": "4"
       }
@@ -8881,12 +9041,10 @@
       "peer": true
     },
     "chromedriver": {
-      "version": "107.0.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-107.0.2.tgz",
-      "integrity": "sha512-EUxGiMo855vyxqUnMciA9dIprwy364rRbdKuKc9fRZ68PSGL0JcvO70c01scYGLfhu9n4KZbM5WXK+dzlmk2cg==",
+      "version": "107.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-107.0.3.tgz",
+      "integrity": "sha512-jmzpZgctCRnhYAn0l/NIjP4vYN3L8GFVbterTrRr2Ly3W5rFMb9H8EKGuM5JCViPKSit8FbE718kZTEt3Yvffg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",
         "axios": "^1.1.3",
@@ -8902,8 +9060,6 @@
           "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
           "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -9018,9 +9174,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.1.tgz",
       "integrity": "sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "compress-commons": {
       "version": "4.1.1",
@@ -9620,14 +9774,15 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -9643,14 +9798,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -9825,8 +9980,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -9839,8 +9992,6 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
           "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -10338,8 +10489,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -10455,9 +10604,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -10533,6 +10680,12 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
       "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA=="
     },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -10558,9 +10711,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -10576,8 +10727,6 @@
       "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
       "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "deep-is": "^0.1.3",
         "ip-regex": "^4.1.0",
@@ -11178,32 +11327,29 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
+      "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -11223,23 +11369,6 @@
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
           }
         },
         "escape-string-regexp": {
@@ -11274,12 +11403,23 @@
           }
         },
         "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
           }
         },
         "ms": {
@@ -11361,9 +11501,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
@@ -11378,9 +11518,9 @@
       "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA=="
     },
     "nightwatch": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.4.2.tgz",
-      "integrity": "sha512-3kDVPT3Na/4yRA2q+/zSTwYUijTmsn+5L4AaqDebWbv1kGHVzv84AFxNIf4hGaCIB79AyhiFnkSj3L065OZZ7w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-2.5.0.tgz",
+      "integrity": "sha512-Y3TkvOLl/KM/j6pjeOD6CR5beCzjupDjAzFRGt0peumt0HTP2d2d4QydB+VXTxGyO0UJX9OmkusGUnKGZt604Q==",
       "dev": true,
       "requires": {
         "@nightwatch/chai": "5.0.2",
@@ -11407,13 +11547,125 @@
         "nightwatch-axe-verbose": "2.0.3",
         "open": "8.4.0",
         "ora": "5.4.1",
-        "selenium-webdriver": "4.3.1",
+        "selenium-webdriver": "4.5.0",
         "semver": "7.3.5",
         "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.1",
+        "untildify": "^4.0.0",
         "uuid": "8.3.2"
       },
       "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "mocha": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+          "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+          "dev": true,
+          "requires": {
+            "@ungap/promise-all-settled": "1.1.2",
+            "ansi-colors": "4.1.1",
+            "browser-stdout": "1.3.1",
+            "chokidar": "3.5.3",
+            "debug": "4.3.3",
+            "diff": "5.0.0",
+            "escape-string-regexp": "4.0.0",
+            "find-up": "5.0.0",
+            "glob": "7.2.0",
+            "growl": "1.10.5",
+            "he": "1.2.0",
+            "js-yaml": "4.1.0",
+            "log-symbols": "4.1.0",
+            "minimatch": "4.2.1",
+            "ms": "2.1.3",
+            "nanoid": "3.3.1",
+            "serialize-javascript": "6.0.0",
+            "strip-json-comments": "3.1.1",
+            "supports-color": "8.1.1",
+            "which": "2.0.2",
+            "workerpool": "6.2.0",
+            "yargs": "16.2.0",
+            "yargs-parser": "20.2.4",
+            "yargs-unparser": "2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+              "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                  "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+              "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+              "dev": true
+            }
+          }
+        },
+        "nanoid": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+          "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -11422,6 +11674,27 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        },
+        "workerpool": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+          "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+          "dev": true
         }
       }
     },
@@ -12027,9 +12300,9 @@
       }
     },
     "selenium-webdriver": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.3.1.tgz",
-      "integrity": "sha512-TjH/ls1WKRQoFEHcqtn6UtwcLnA3yvx08v9cSSFYvyhp8hJWRtbe9ae2I8uXPisEZ2EaGKKoxBZ4EHv0BJM15g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz",
+      "integrity": "sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==",
       "dev": true,
       "requires": {
         "jszip": "^3.10.0",
@@ -12302,8 +12575,6 @@
       "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
       "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "debug": "4.3.1",
         "is2": "^2.0.6"
@@ -12314,8 +12585,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -12543,9 +12812,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -12595,9 +12864,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "wrap-ansi": {
@@ -12616,9 +12885,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
-    "chromedriver": "^107.0.3",
     "eslint": "^8.27.0",
     "mocha": "^10.1.0",
     "mockery": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "build": "tsc",
     "prepublishOnly": "tsc --outDir dist",
     "create-nightwatch": "tsc && node dev-run.js",
-    "test:unit": "npx nightwatch tests/unit_tests",
-    "test:e2e": "npx nightwatch tests/e2e_tests"
+    "esbuild": "esbuild --bundle src/index.ts --outdir=dist --platform=node --target=ES2019",
+    "test:unit": "npx nightwatch test/unit_tests",
+    "test:e2e": "npx nightwatch test/e2e_tests"
   },
   "keywords": [],
   "author": "Priyansh Garg",
@@ -31,9 +32,11 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
-    "eslint": "^8.17.0",
+    "chromedriver": "^107.0.3",
+    "eslint": "^8.27.0",
+    "mocha": "^10.1.0",
     "mockery": "^2.1.0",
-    "nightwatch": "^2.1.8",
+    "nightwatch": "^2.5.0",
     "nock": "^13.2.9",
     "typescript": "^4.7.3"
   },
@@ -45,6 +48,6 @@
     "ejs": "^3.1.8",
     "inquirer": "^8.2.4",
     "minimist": "^1.2.6",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.0"
   }
 }

--- a/src/config/main.ejs
+++ b/src/config/main.ejs
@@ -631,10 +631,11 @@ module.exports = {
       }
     }<% }} %>
   },
-
+  <% if (answers.allowAnonymousMetrics) { %>
   usage_analytics: {
-    enabled: <%- answers.allowAnonymousMetrics %>,
+    enabled: true,
     log_path: './logs/analytics',
     client_id: '<%- client_id %>'
   }
+  <% } %>
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const CONFIG_INTRO = `===============================
 Nightwatch Configuration Wizard
 ===============================
 
-Initializing a new project in %s...
+Initializing project in %s...
 `;
 
 export const AVAILABLE_CONFIG_FLAGS = ['yes', 'generate-config', 'browser', 'y', 'b', 'mobile'];
@@ -99,7 +99,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
     message: 'Select target browsers',
     choices: (answers) => {
       let browsers = BROWSER_CHOICES;
-      if (answers.backend === 'local' && process.platform !== 'darwin') {
+      if (process.platform !== 'darwin') {
         browsers = browsers.filter((browser) => browser.value !== 'safari');
       }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,9 +17,7 @@ export const CONFIG_INTRO = `===============================
 Nightwatch Configuration Wizard
 ===============================
 
-Just answer a few questions to get started with Nightwatch:
-
-We'll setup everything for you :-)
+Initializing a new project in %s...
 `;
 
 export const AVAILABLE_CONFIG_FLAGS = ['yes', 'generate-config', 'browser', 'y', 'b', 'mobile'];
@@ -73,12 +71,13 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'list',
     name: 'languageRunnerSetup',
-    message: 'What is your Language - Test Runner setup?',
+    message: 'Select language & test runner variant',
     choices: [
-      {name: 'JavaScript - Nightwatch Test Runner', value: 'js-nightwatch'},
-      {name: 'JavaScript - Mocha Test Runner', value: 'js-mocha'},
-      {name: 'JavaScript - CucumberJS Test Runner', value: 'js-cucumber'},
-      {name: 'TypeScript - Nightwatch Test Runner', value: 'ts-nightwatch'}
+      {name: 'JavaScript / default', value: 'js-nightwatch'},
+      {name: 'TypeScript / default', value: 'ts-nightwatch'},
+      {name: 'JavaScript / Mocha', value: 'js-mocha'},
+      {name: 'JavaScript / CucumberJS', value: 'js-cucumber'},
+
       // {name: 'TypeScript - Mocha Test Runner', value: 'ts-mocha'}
       // {name: 'TypeScript - CucumberJS Test Runner', value: 'ts-cucumber'}
     ],
@@ -95,10 +94,10 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'list',
     name: 'backend',
-    message: 'Where do you want to run your e2e tests?',
+    message: 'Select where to run end-to-end tests',
     choices: [
-      {name: 'On my local machine', value: 'local'},
-      {name: 'On a remote machine (cloud)', value: 'remote'},
+      {name: 'On localhost', value: 'local'},
+      {name: 'On a remote/cloud service', value: 'remote'},
       {name: 'Both', value: 'both'}
     ],
     default: 'local'
@@ -107,7 +106,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'list',
     name: 'cloudProvider',
-    message: '(Remote) Please select your cloud provider:',
+    message: '(Remote) Select your cloud provider:',
     choices: [
       {name: 'BrowserStack', value: 'browserstack'},
       {name: 'Sauce Labs', value: 'saucelabs'},
@@ -120,7 +119,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'checkbox',
     name: 'browsers',
-    message: 'Which browsers will you be testing on?',
+    message: 'Choose target browsers',
     choices: (answers) => {
       let browsers = BROWSER_CHOICES;
       if (answers.backend === 'local' && process.platform !== 'darwin') {
@@ -142,14 +141,14 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'input',
     name: 'testsLocation',
-    message: 'Where do you plan to keep your end-to-end tests?',
+    message: 'Enter source folder where test files will be located',
     default: 'tests'
   },
 
   {
     type: 'input',
     name: 'featurePath',
-    message: 'Where do you plan to keep your CucumberJS feature files?',
+    message: 'Enter location of CucumberJS feature files',
     default: (answers: { testsLocation: string }) => path.join(answers.testsLocation, 'features'),
     when: (answers) => answers.runner === 'cucumber'
   },
@@ -158,7 +157,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'input',
     name: 'baseUrl',
-    message: 'What is the base_url of your project?',
+    message: 'Enter the base_url of the project',
     default: 'http://localhost'
   },
 
@@ -166,7 +165,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'confirm',
     name: 'allowAnonymousMetrics',
-    message: 'Allow Nightwatch to anonymously collect usage metrics?',
+    message: 'Allow Nightwatch to collect completely anonymous usage metrics?',
     default: false
   },
   
@@ -174,7 +173,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'list',
     name: 'mobile',
-    message: 'Would you like to run your e2e tests on Mobile devices as well?',
+    message: 'Setup testing on Mobile devices as well?',
     choices: () => [
       {name: 'Yes', value: true},
       {name: 'No, skip for now', value: false}
@@ -189,17 +188,17 @@ export const CONFIG_DEST_QUES: inquirer.QuestionCollection = [
   {
     type: 'list',
     name: 'overwrite',
-    message: 'Do you want to overwrite the existing config file?',
+    message: 'Overwrite the existing config file?',
     default: false,
     choices: [
       {name: 'Yes', value: true},
-      {name: 'No, create a new one!', value: false}
+      {name: 'No, create a new one', value: false}
     ]
   },
   {
     type: 'input',
     name: 'newFileName',
-    message: 'What should your new config file be called?',
+    message: 'Enter new config file name:',
     validate: (value, answers) => {
       if (!value.length) {
         return 'File name cannot be empty.';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,7 @@ export const MOBILE_BROWSER_CHOICES = [
   {name: 'Safari (iOS)', value: 'safari'}
 ];
 
-export const MOBILE_BROWSER_QUES: inquirer.QuestionCollection = 
+export const MOBILE_BROWSER_QUES: inquirer.QuestionCollection =
 {
   type: 'checkbox',
   name: 'mobileBrowsers',
@@ -59,7 +59,7 @@ export const MOBILE_BROWSER_QUES: inquirer.QuestionCollection =
 
     const browsersHasMobileBrowsers = (answers.browsers as string[] | undefined)
       ?.some(((browser: string) => mobileBrowserValues.includes(browser)));
-    
+
     return answers.mobile && answers.backend !== 'remote' && !browsersHasMobileBrowsers;
   }
 };
@@ -97,7 +97,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
     type: 'checkbox',
     name: 'browsers',
     message: 'Select target browsers',
-    choices: (answers) => {
+    choices: () => {
       let browsers = BROWSER_CHOICES;
       if (process.platform !== 'darwin') {
         browsers = browsers.filter((browser) => browser.value !== 'safari');
@@ -170,7 +170,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
     message: 'Allow Nightwatch to collect completely anonymous usage metrics?',
     default: false
   },
-  
+
   // TEST ON MOBILE
   {
     type: 'list',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,7 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'list',
     name: 'languageRunnerSetup',
-    message: 'Select language & test runner variant',
+    message: 'Select language + test runner variant',
     choices: [
       {name: 'JavaScript / default', value: 'js-nightwatch'},
       {name: 'TypeScript / default', value: 'ts-nightwatch'},
@@ -90,36 +90,13 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
     }
   },
 
-  // TESTING BACKEND
-  {
-    type: 'list',
-    name: 'backend',
-    message: 'Select where to run end-to-end tests',
-    choices: [
-      {name: 'On localhost', value: 'local'},
-      {name: 'On a remote/cloud service', value: 'remote'},
-      {name: 'Both', value: 'both'}
-    ],
-    default: 'local'
-  },
 
-  {
-    type: 'list',
-    name: 'cloudProvider',
-    message: '(Remote) Select your cloud provider:',
-    choices: [
-      {name: 'BrowserStack', value: 'browserstack'},
-      {name: 'Sauce Labs', value: 'saucelabs'},
-      {name: 'Other providers or remote selenium-server', value: 'other'}
-    ],
-    when: (answers) => ['remote', 'both'].includes(answers.backend)
-  },
 
   // BROWSERS
   {
     type: 'checkbox',
     name: 'browsers',
-    message: 'Choose target browsers',
+    message: 'Select target browsers',
     choices: (answers) => {
       let browsers = BROWSER_CHOICES;
       if (answers.backend === 'local' && process.platform !== 'darwin') {
@@ -141,8 +118,8 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
   {
     type: 'input',
     name: 'testsLocation',
-    message: 'Enter source folder where test files will be located',
-    default: 'tests'
+    message: 'Enter source folder where test files are stored',
+    default: 'test'
   },
 
   {
@@ -159,6 +136,31 @@ export const QUESTIONAIRRE: inquirer.QuestionCollection = [
     name: 'baseUrl',
     message: 'Enter the base_url of the project',
     default: 'http://localhost'
+  },
+
+  // TESTING BACKEND
+  {
+    type: 'list',
+    name: 'backend',
+    message: 'Select where to run Nightwatch tests',
+    choices: [
+      {name: 'On localhost', value: 'local'},
+      {name: 'On a remote/cloud service', value: 'remote'},
+      {name: 'Both', value: 'both'}
+    ],
+    default: 'local'
+  },
+
+  {
+    type: 'list',
+    name: 'cloudProvider',
+    message: '(Remote) Select cloud provider:',
+    choices: [
+      {name: 'BrowserStack', value: 'browserstack'},
+      {name: 'Sauce Labs', value: 'saucelabs'},
+      {name: 'Other providers or remote selenium-server', value: 'other'}
+    ],
+    when: (answers) => ['remote', 'both'].includes(answers.backend)
   },
 
   // ANONYMOUS METRIC COLLECTION

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,11 +40,10 @@ export const run = async () => {
       }
     }
 
-    Logger.error(NIGHTWATCH_TITLE);
-
-    await checkCreateNightwatchVersion();
-
     let rootDir = path.resolve(process.cwd(), args[0] || '');
+
+    Logger.info(NIGHTWATCH_TITLE);
+    await checkCreateNightwatchVersion();
 
     if (options?.['generate-config'] && !isNodeProject(rootDir)) {
       throw new Error(`package.json not found. Please run this command from your existing Nightwatch project.
@@ -70,7 +69,7 @@ export const run = async () => {
 };
 
 export const confirmRootDir = async (rootDir: string): Promise<string> => {
-  Logger.error(`${colors.yellow('Warning:')} Current working directory is not a node project and contains some files.`);
+  Logger.warn(`${colors.yellow('Warning:')} Current working directory is not a node project and already contains some files.`);
 
   const answers = await prompt([
     {
@@ -92,7 +91,7 @@ export const confirmRootDir = async (rootDir: string): Promise<string> => {
     }
   ]);
   // Insert a blank line after prompt.
-  Logger.error();
+  Logger.info();
 
   if (answers.confirm) {
     return rootDir;
@@ -106,7 +105,7 @@ export const initializeNodeProject = (rootDir: string) => {
     fs.mkdirSync(rootDir, {recursive: true});
   }
 
-  Logger.error(`${colors.yellow('package.json')} not found in the root directory. Initializing a new NPM project..\n`);
+  Logger.info(`${colors.yellow('package.json')} not found in the root directory. Initializing a new NPM project..\n`);
 
   execSync('npm init -y', {
     stdio: 'inherit',
@@ -128,8 +127,8 @@ export const checkCreateNightwatchVersion = async () => {
   const currentVersion = process.env.npm_package_version;
 
   if (latestVersion && currentVersion && latestVersion !== currentVersion) {
-    Logger.error(
-      `We've updated this onboarding tool. ${colors.red(currentVersion)} -> ${colors.green(
+    Logger.info(
+      `We've updated this onboarding tool: ${colors.red(currentVersion)} -> ${colors.green(
         latestVersion
       )}. To get the latest experience, run: ${colors.green('npm init nightwatch@latest')}\n\n`
     );

--- a/src/init.ts
+++ b/src/init.ts
@@ -723,7 +723,7 @@ export class NightwatchInit {
 
     // Join Discord and GitHub
     Logger.info('💬 Join our Discord community to find answers to your issues or queries. Or just join and say hi.');
-    Logger.info(colors.cyan('  https://discord.gg/SN8Da2X'), '\n');
+    Logger.info(colors.cyan('   https://discord.gg/SN8Da2X'), '\n');
 
     if (!this.options?.mobile) {
       Logger.info(colors.green('🚀 RUN EXAMPLE TESTS'), '\n');

--- a/src/init.ts
+++ b/src/init.ts
@@ -16,6 +16,7 @@ import {ConfigGeneratorAnswers, ConfigDestination, OtherInfo, MobileResult} from
 import defaultAnswers from './defaults.json';
 import defaultMobileAnswers from './defaultsMobile.json';
 import {AndroidSetup, IosSetup} from '@nightwatch/mobile-helper';
+import { format } from 'node:util';
 
 
 const EXAMPLE_TEST_FOLDER = 'examples';
@@ -63,11 +64,11 @@ export class NightwatchInit {
         }
       }
     } else {
-      Logger.error(CONFIG_INTRO);
+      Logger.info(format(CONFIG_INTRO, this.rootDir));
 
       answers = await this.askQuestions();
       // Add a newline after questions.
-      Logger.error();
+      Logger.info();
     }
 
     this.refineAnswers(answers);
@@ -121,13 +122,13 @@ export class NightwatchInit {
       // answers.mobileDevice will be undefined in case of empty or non-matching mobileBrowsers
       // hence, no need to setup any device.
       if (['android', 'both'].includes(answers.mobileDevice)) {
-        Logger.error('Running Android Setup...\n');
+        Logger.info('Running Android Setup...\n');
         const androidSetup = new AndroidSetup({browsers: answers.mobileBrowsers || []}, this.rootDir);
         mobileResult.android = await androidSetup.run();
       }
 
       if (['ios', 'both'].includes(answers.mobileDevice)) {
-        Logger.error('Running iOS Setup...\n');
+        Logger.info('Running iOS Setup...\n');
         const iosSetup = new IosSetup({mode: ['simulator', 'real'], setup: true});
         mobileResult.ios = await iosSetup.run();
       }
@@ -314,21 +315,21 @@ export class NightwatchInit {
       return;
     }
 
-    Logger.error('Installing the following packages:');
+    Logger.info('Installing the following packages:');
     for (const pack of packagesToInstall) {
-      Logger.error(`- ${pack}`);
+      Logger.info(`- ${pack}`);
     }
-    Logger.error();
+    Logger.info();
 
     for (const pack of packagesToInstall) {
-      Logger.error(`Installing ${colors.green(pack)}`);
+      Logger.info(`Installing ${colors.green(pack)}`);
 
       try {
         execSync(`npm install ${pack} --save-dev`, {
           stdio: ['inherit', 'pipe', 'inherit'],
           cwd: this.rootDir
         });
-        Logger.error(colors.green('Done!'), '\n');
+        Logger.info(colors.green('Done!'), '\n');
       } catch (err) {
         Logger.error(`Failed to install ${pack}. Please run 'npm install ${pack} --save-dev' later.\n`);
       }
@@ -344,7 +345,7 @@ export class NightwatchInit {
         stdio: 'inherit',
         cwd: this.rootDir
       });
-      Logger.error();
+      Logger.info();
     }
 
     // Generate a new tsconfig.json file to be used by ts-node, if not already present.
@@ -380,19 +381,19 @@ export class NightwatchInit {
 
   async getConfigDestPath() {
     if (this.options?.yes) {
-      Logger.error('Auto-generating a configuration file...\n');
+      Logger.info('Auto-generating a configuration file...\n');
     } else {
-      Logger.error('Generting a configuration file based on your responses...\n');
+      Logger.info('Generating a configuration file based on your responses...\n');
     }
 
     const configDestPath = path.join(this.rootDir, 'nightwatch.conf.js');
 
     if (fs.existsSync(configDestPath)) {
-      Logger.error(colors.yellow(`There seems to be another config file located at "${configDestPath}".\n`));
+      Logger.info(colors.yellow(`There seems to be another config file located at "${configDestPath}".\n`));
 
       const answers: ConfigDestination = await prompt(CONFIG_DEST_QUES, {rootDir: this.rootDir});
       // Adding a newline after questions.
-      Logger.error();
+      Logger.info();
 
       if (!answers.overwrite) {
         const configFileName = `${answers.newFileName}.conf.js`;
@@ -468,13 +469,13 @@ export class NightwatchInit {
     try {
       fs.writeFileSync(configDestPath, rendered, {encoding: 'utf-8'});
 
-      Logger.error(`${colors.green(symbols().ok + ' Success!')} Configuration file generated at: "${configDestPath}".`);
+      Logger.info(`${colors.green(symbols().ok + ' Success!')} Configuration file generated at: "${configDestPath}".`);
 
       if (this.otherInfo.nonDefaultConfigName) {
-        Logger.error(`To use this configuration file, run the tests using ${colors.magenta('--config')} flag.`);
+        Logger.info(`To use this configuration file, run the tests using ${colors.magenta('--config')} flag.`);
       }
       // Add a newline
-      Logger.error();
+      Logger.info();
 
       return true;
     } catch (err) {
@@ -504,11 +505,11 @@ export class NightwatchInit {
   }
 
   async installWebdrivers(webdriversToInstall: string[]) {
-    Logger.error('Installing/updating the following webdrivers:');
+    Logger.info('Installing/updating the following webdrivers:');
     for (const webdriver of webdriversToInstall) {
-      Logger.error(`- ${webdriver}`);
+      Logger.info(`- ${webdriver}`);
     }
-    Logger.error();
+    Logger.info();
 
     const driversDownloadedFromNPM: { [key: string]: string } = {
       geckodriver: 'Firefox',
@@ -517,13 +518,13 @@ export class NightwatchInit {
 
     for (const webdriver of webdriversToInstall) {
       if (webdriver in driversDownloadedFromNPM) {
-        Logger.error(`Installing webdriver for ${driversDownloadedFromNPM[webdriver]} (${webdriver})...`);
+        Logger.info(`Installing webdriver for ${driversDownloadedFromNPM[webdriver]} (${webdriver})...`);
         try {
           execSync(`npm install ${webdriver} --save-dev`, {
             stdio: ['inherit', 'pipe', 'inherit'],
             cwd: this.rootDir
           });
-          Logger.error(colors.green('Done!'), '\n');
+          Logger.info(colors.green('Done!'), '\n');
         } catch (err) {
           Logger.error(`Failed to install ${webdriver}. Please run 'npm install ${webdriver} --save-dev' later.\n`);
         }
@@ -546,15 +547,15 @@ export class NightwatchInit {
         ]);
 
         if (answers.safaridriver) {
-          Logger.error();
-          Logger.error('Enabling safaridriver...');
+          Logger.info();
+          Logger.info('Enabling safaridriver...');
           execSync('sudo safaridriver --enable', {
             stdio: ['inherit', 'pipe', 'inherit'],
             cwd: this.rootDir
           });
-          Logger.error(colors.green('Done!'), '\n');
+          Logger.info(colors.green('Done!'), '\n');
         } else {
-          Logger.error('Please run \'sudo safaridriver --enable\' command to enable safaridriver later.\n');
+          Logger.info('Please run \'sudo safaridriver --enable\' command to enable safaridriver later.\n');
         }
       } catch (err) {
         Logger.error('Failed to enable safaridriver. Please run \'sudo safaridriver --enable\' later.\n');
@@ -577,12 +578,12 @@ export class NightwatchInit {
       return;
     }
 
-    Logger.error('Generating example for CucumberJS...');
+    Logger.info('Generating example for CucumberJS...');
     this.otherInfo.cucumberExamplesAdded = true;
 
     const exampleDestPath = path.join(this.rootDir, examplesLocation);
     if (fs.existsSync(exampleDestPath)) {
-      Logger.error(`Example already exists at '${examplesLocation}'. Skipping...`, '\n');
+      Logger.info(`Example already exists at '${examplesLocation}'. Skipping...`, '\n');
 
       return;
     }
@@ -592,13 +593,13 @@ export class NightwatchInit {
     const exampleSrcPath = path.join(nightwatchModulePath, 'examples', 'cucumber-js', 'features');
 
     copy(exampleSrcPath, exampleDestPath);
-    Logger.error(
+    Logger.info(
       `${colors.green(symbols().ok + ' Success!')} Generated an example for CucumberJS at "${examplesLocation}".\n`
     );
   }
 
   copyExamples(examplesLocation: string, typescript: boolean) {
-    Logger.error('Generating example files...');
+    Logger.info('Generating example files...');
 
     const examplesDestPath = path.join(this.rootDir, examplesLocation);  // this is different from this.otherInfo.examplesJsSrc
     try {
@@ -609,7 +610,7 @@ export class NightwatchInit {
     const examplesDestFiles = fs.readdirSync(examplesDestPath);
 
     if ((typescript && examplesDestFiles.length > 1) || (!typescript && examplesDestFiles.length > 0)) {
-      Logger.error(`Examples already exists at '${examplesLocation}'. Skipping...`, '\n');
+      Logger.info(`Examples already exists at '${examplesLocation}'. Skipping...`, '\n');
 
       return;
     }
@@ -623,14 +624,14 @@ export class NightwatchInit {
 
     copy(examplesSrcPath, examplesDestPath);
 
-    Logger.error(
+    Logger.info(
       `${colors.green(symbols().ok + ' Success!')} Generated some example files at '${examplesLocation}'.\n`
     );
   }
 
 
   copyTemplates(examplesLocation: string) {
-    Logger.error('Generating template files...');
+    Logger.info('Generating template files...');
 
     const templatesLocation = path.join(examplesLocation, 'templates');
 
@@ -642,7 +643,7 @@ export class NightwatchInit {
     } catch (err) {}
 
     if (fs.readdirSync(templatesDestPath).length) {
-      Logger.error(`Templates already exists at '${templatesLocation}'. Skipping...`, '\n');
+      Logger.info(`Templates already exists at '${templatesLocation}'. Skipping...`, '\n');
 
       return;
     }
@@ -651,63 +652,55 @@ export class NightwatchInit {
     
     copy(templatesSrcPath, templatesDestPath);
 
-    Logger.error(
+    Logger.info(
       `${colors.green(symbols().ok + ' Success!')} Generated some templates files at '${templatesLocation}'.\n`
     );
   }
 
   postSetupInstructions(answers: ConfigGeneratorAnswers, mobileResult: MobileResult) {
-    Logger.error('Nightwatch setup complete!!\n');
-
-    // Join Discord and GitHub
-    Logger.error('Join our Discord community and instantly find answers to your issues or queries. Or just join and say hi!');
-    Logger.error(colors.cyan('  https://discord.gg/SN8Da2X'), '\n');
-
-    Logger.error('Visit our GitHub page to report bugs or raise feature requests:');
-    Logger.error(colors.cyan('  https://github.com/nightwatchjs/nightwatch'), '\n');
 
     // Instructions for setting host, port, username and passowrd for remote.
     if (answers.backend && ['remote', 'both'].includes(answers.backend)) {
-      Logger.error(colors.red('IMPORTANT'));
+      Logger.info(colors.red('IMPORTANT'));
       if (answers.cloudProvider === 'other') {
         let configFileName = 'nightwatch.conf.js';
         if (this.otherInfo.nonDefaultConfigName) {
           configFileName = this.otherInfo.nonDefaultConfigName;
         }
-        Logger.error(
+        Logger.info(
           `To run tests on your remote device, please set the ${colors.magenta('host')} and ${colors.magenta('port')} property in your ${configFileName} file.` 
         );
-        Logger.error('These can be located at:');
-        Logger.error(
+        Logger.info('These can be located at:');
+        Logger.info(
           `{\n  ...\n  "test_settings": {\n    ...\n    "${answers.remoteName}": {\n      "selenium": {\n        ${colors.cyan(
             '"host":')}\n        ${colors.cyan('"port":')}\n      }\n    }\n  }\n}`,
           '\n'
         );
 
-        Logger.error(
+        Logger.info(
           'Please set the credentials (if any) required to run tests on your cloud provider or remote selenium-server, by setting the below env variables:'
         );
       } else {
-        Logger.error(
+        Logger.info(
           'Please set the credentials required to run tests on your cloud provider, by setting the below env variables:'
         );
       }
 
-      Logger.error(`- ${colors.cyan(answers.remoteEnv?.username as string)}`);
-      Logger.error(`- ${colors.cyan(answers.remoteEnv?.access_key as string)}`);
-      Logger.error('(.env files are also supported)', '\n');
+      Logger.info(`- ${colors.cyan(answers.remoteEnv?.username as string)}`);
+      Logger.info(`- ${colors.cyan(answers.remoteEnv?.access_key as string)}`);
+      Logger.info('(.env files are also supported)', '\n');
     }
-    Logger.error();
+    Logger.info();
 
     const relativeToRootDir = path.relative(process.cwd(), this.rootDir) || '.';
 
     // For now the templates added only for JS
     if (answers.runner !== Runner.Cucumber && answers.language !== 'ts') {
-      Logger.error(colors.green('TEMPLATE TESTS'), '\n');
-      Logger.error('To get started, checkout the following templates. Skip/delete them if you are an experienced user.');
-      Logger.error(colors.cyan(`  1. Title Assertion (${path.join(relativeToRootDir, answers.examplesLocation || '', 'templates', 'titleAssertion.js')})`));
-      Logger.error(colors.cyan(`  2. Login (${path.join(relativeToRootDir, answers.examplesLocation || '', 'templates', 'login.js')})`));
-      Logger.error();
+      Logger.info(colors.green('📃 TEMPLATE TESTS'), '\n');
+      Logger.info('To get started, checkout the following templates. Skip/delete them if you are an experienced user.');
+      Logger.info(colors.cyan(`  1. Title Assertion (${path.join(relativeToRootDir, answers.examplesLocation || '', 'templates', 'titleAssertion.js')})`));
+      Logger.info(colors.cyan(`  2. Login (${path.join(relativeToRootDir, answers.examplesLocation || '', 'templates', 'login.js')})`));
+      Logger.info();
     }
   
     let configFlag = '';
@@ -715,11 +708,21 @@ export class NightwatchInit {
       configFlag = ` --config ${this.otherInfo.nonDefaultConfigName}`;
     }
 
+    Logger.info(colors.green('✨ SETUP COMPLETE'));
+    execSync('npx nightwatch --version', {
+      stdio: 'inherit',
+      cwd: this.rootDir
+    });
+
+    // Join Discord and GitHub
+    Logger.info('💬 Join our Discord community to find answers to your issues or queries. Or just join and say hi.');
+    Logger.info(colors.cyan('  https://discord.gg/SN8Da2X'), '\n');
+
     if (!this.options?.mobile) {
-      Logger.error(colors.green('RUN NIGHTWATCH TESTS'), '\n');
+      Logger.info(colors.green('🚀 RUN EXAMPLE TESTS'), '\n');
       if (this.rootDir !== process.cwd()) {
-        Logger.error('First, change directory to the root dir of your project:');
-        Logger.error(colors.cyan(`  cd ${relativeToRootDir}`), '\n');
+        Logger.info('First, change directory to the root dir of your project:');
+        Logger.info(colors.cyan(`  cd ${relativeToRootDir}`), '\n');
       }
 
       let envFlag = '';
@@ -728,27 +731,27 @@ export class NightwatchInit {
       }
 
       if (answers.runner === Runner.Cucumber) {
-        Logger.error('To run your tests with CucumberJS, simply run:');
-        Logger.error(colors.cyan(`  npx nightwatch${envFlag}${configFlag}`), '\n');
+        Logger.info('To run your tests with CucumberJS, simply run:');
+        Logger.info(colors.cyan(`  npx nightwatch${envFlag}${configFlag}`), '\n');
 
         if (this.otherInfo.cucumberExamplesAdded) {
-          Logger.error('To run an example test with CucumberJS, run:');
-          Logger.error(colors.cyan(`  npx nightwatch ${answers.examplesLocation}${envFlag}${configFlag}`), '\n');
+          Logger.info('To run an example test with CucumberJS, run:');
+          Logger.info(colors.cyan(`  npx nightwatch ${answers.examplesLocation}${envFlag}${configFlag}`), '\n');
         }
 
-        Logger.error('For more details on using CucumberJS with Nightwatch, visit:');
-        Logger.error(
+        Logger.info('For more details on using CucumberJS with Nightwatch, visit:');
+        Logger.info(
           colors.cyan('  https://nightwatchjs.org/guide/third-party-runners/cucumberjs-nightwatch-integration.html')
         );
       } else if (answers.addExamples) {
         if (answers.language === 'ts') {
-          Logger.error('To run all examples, run:');
-          Logger.error(
+          Logger.info('To run all examples, run:');
+          Logger.info(
             colors.cyan(`  npx nightwatch .${path.sep}${this.otherInfo.examplesJsSrc}${envFlag}${configFlag}\n`)
           );
 
-          Logger.error('To run a single example (github.ts), run:');
-          Logger.error(
+          Logger.info('To run a single example (github.ts), run:');
+          Logger.info(
             colors.cyan(
               `  npx nightwatch .${path.sep}${path.join(
                 this.otherInfo.examplesJsSrc || '',
@@ -757,8 +760,8 @@ export class NightwatchInit {
             )
           );
         } else {
-          Logger.error('To run all examples, run:');
-          Logger.error(
+          Logger.info('To run all examples, run:');
+          Logger.info(
             colors.cyan(
               `  npx nightwatch .${path.sep}${path.join(
                 this.otherInfo.examplesJsSrc || '',
@@ -767,8 +770,8 @@ export class NightwatchInit {
             )
           );
 
-          Logger.error('To run a single example (ecosia.js), run:');
-          Logger.error(
+          Logger.info('To run a single example (ecosia.js), run:');
+          Logger.info(
             colors.cyan(
               `  npx nightwatch .${path.sep}${path.join(
                 this.otherInfo.examplesJsSrc || '',
@@ -780,10 +783,10 @@ export class NightwatchInit {
           );
         }
       } else {
-        Logger.error(`A few examples are available at '${path.join('node_modules', 'nightwatch', 'examples')}'.\n`);
+        Logger.info(`A few examples are available at '${path.join('node_modules', 'nightwatch', 'examples')}'.\n`);
 
-        Logger.error('To run a single example (ecosia.js), try:');
-        Logger.error(
+        Logger.info('To run a single example (ecosia.js), try:');
+        Logger.info(
           colors.cyan(
             `  npx nightwatch ${path.join(
               'node_modules',
@@ -796,8 +799,8 @@ export class NightwatchInit {
           '\n'
         );
 
-        Logger.error('To run all examples, try:');
-        Logger.error(
+        Logger.info('To run all examples, try:');
+        Logger.info(
           colors.cyan(`  npx nightwatch ${path.join('node_modules', 'nightwatch', 'examples')}${envFlag}${configFlag}`),
           '\n'
         );
@@ -805,24 +808,24 @@ export class NightwatchInit {
     }
 
     if (answers.seleniumServer) {
-      Logger.error('[Selenium Server]\n');
+      Logger.info('[Selenium Server]\n');
       if (this.otherInfo.javaNotInstalled) {
-        Logger.error(
+        Logger.info(
           'Java Development Kit (minimum v7) is required to run selenium-server locally. Download from here:'
         );
-        Logger.error(colors.cyan('  https://www.oracle.com/technetwork/java/javase/downloads/index.html'), '\n');
+        Logger.info(colors.cyan('  https://www.oracle.com/technetwork/java/javase/downloads/index.html'), '\n');
       }
 
-      Logger.error('To run tests on your local selenium-server, use command:');
-      Logger.error(colors.cyan(`  npx nightwatch --env selenium_server${configFlag}`), '\n');
+      Logger.info('To run tests on your local selenium-server, use command:');
+      Logger.info(colors.cyan(`  npx nightwatch --env selenium_server${configFlag}`), '\n');
     }
 
     if (answers.browsers?.includes('edge')) {
-      Logger.error(`${colors.red('Note:')} Microsoft Edge Webdriver is not installed automatically.`);
-      Logger.error(
+      Logger.info(`${colors.red('Note:')} Microsoft Edge Webdriver is not installed automatically.`);
+      Logger.info(
         'Please follow the below link ("Download" and "Standalone Usage" sections) to setup EdgeDriver manually:'
       );
-      Logger.error(colors.cyan('  https://nightwatchjs.org/guide/browser-drivers-setup/edgedriver.html'), '\n');
+      Logger.info(colors.cyan('  https://nightwatchjs.org/guide/browser-drivers-setup/edgedriver.html'), '\n');
     }
 
     // MOBILE TESTS
@@ -854,7 +857,7 @@ export class NightwatchInit {
     };
 
     if (answers.mobileDevice) {
-      Logger.error(colors.green('RUN NIGHTWATCH TESTS ON MOBILE'), '\n');
+      Logger.info(colors.green('RUN NIGHTWATCH TESTS ON MOBILE'), '\n');
 
       if (['android', 'both'].includes(answers.mobileDevice)) {
         const errorHelp = 'Please go through the setup logs above to know the actual cause of failure.\n\nOr, re-run the following commands:';
@@ -914,7 +917,7 @@ export class NightwatchInit {
               )}\n\n${errorHelp}\n${setupMsg}\n\n${testCommands}`, {padding: 1})
             );
           } else {
-            Logger.error(
+            Logger.info(
               boxen(`${colors.red(
                 'Android setup skipped...'
               )}\n\n${setupMsg}\n\n${testCommands}`, {padding: 1})
@@ -923,16 +926,16 @@ export class NightwatchInit {
         } else {
           // mobileResult.android.status is true.
           if (this.rootDir !== process.cwd()) {
-            Logger.error('First, change directory to the root dir of your project:');
-            Logger.error(colors.cyan(`  cd ${relativeToRootDir}`), '\n');
+            Logger.info('First, change directory to the root dir of your project:');
+            Logger.info(colors.cyan(`  cd ${relativeToRootDir}`), '\n');
           }
 
           if (['real', 'both'].includes(mobileResult.android.mode)) {
-            Logger.error(realAndroidTestCommand(), '\n');
+            Logger.info(realAndroidTestCommand(), '\n');
           }
 
           if (['emulator', 'both'].includes(mobileResult.android.mode)) {
-            Logger.error(emulatorAndroidTestCommand(), '\n');
+            Logger.info(emulatorAndroidTestCommand(), '\n');
           }
         }
       }
@@ -963,11 +966,11 @@ export class NightwatchInit {
           );
         } else if (typeof mobileResult.ios === 'object') {
           if (mobileResult.ios.real) {
-            Logger.error(realIosTestCommand, '\n');
+            Logger.info(realIosTestCommand, '\n');
           }
           
           if (mobileResult.ios.simulator) {
-            Logger.error(simulatorIosTestCommand, '\n');
+            Logger.info(simulatorIosTestCommand, '\n');
           }
   
           if (!mobileResult.ios.real || !mobileResult.ios.simulator) {
@@ -981,28 +984,28 @@ export class NightwatchInit {
       }
     } else if (this.options?.mobile && answers.mobileRemote && answers.cloudProvider === 'browserstack') {
       // no other test run commands are printed and remote mobile is selected.
-      Logger.error(colors.green('RUN NIGHTWATCH TESTS ON MOBILE'), '\n');
+      Logger.info(colors.green('RUN NIGHTWATCH TESTS ON MOBILE'), '\n');
       if (this.rootDir !== process.cwd()) {
-        Logger.error('First, change directory to the root dir of your project:');
-        Logger.error(colors.cyan(`  cd ${relativeToRootDir}`), '\n');
+        Logger.info('First, change directory to the root dir of your project:');
+        Logger.info(colors.cyan(`  cd ${relativeToRootDir}`), '\n');
       }
 
       const chromeEnvFlag = ' --env browserstack.android.chrome';
       const safariEnvFlag = ' --env browserstack.ios.safari';
 
       if (answers.runner === Runner.Cucumber) {
-        Logger.error('To run your tests with CucumberJS, simply run:');
-        Logger.error('  Chrome: ', colors.cyan(`${cucumberExample}${chromeEnvFlag}`), '\n');
-        Logger.error('  Safari: ', colors.cyan(`${cucumberExample}${safariEnvFlag}`), '\n');
+        Logger.info('To run your tests with CucumberJS, simply run:');
+        Logger.info('  Chrome: ', colors.cyan(`${cucumberExample}${chromeEnvFlag}`), '\n');
+        Logger.info('  Safari: ', colors.cyan(`${cucumberExample}${safariEnvFlag}`), '\n');
       } else if (answers.addExamples) {
         if (answers.language === 'ts') {
-          Logger.error('To run an example test (github.ts), run:');
-          Logger.error('  Chrome: ', colors.cyan(`${tsExample}${chromeEnvFlag}`), '\n');
-          Logger.error('  Safari: ', colors.cyan(`${tsExample}${safariEnvFlag}`), '\n');
+          Logger.info('To run an example test (github.ts), run:');
+          Logger.info('  Chrome: ', colors.cyan(`${tsExample}${chromeEnvFlag}`), '\n');
+          Logger.info('  Safari: ', colors.cyan(`${tsExample}${safariEnvFlag}`), '\n');
         } else {
-          Logger.error('To run an example test (ecosia.js), run:');
-          Logger.error('  Chrome: ', colors.cyan(`${jsExample}${chromeEnvFlag}`), '\n');
-          Logger.error('  Safari: ', colors.cyan(`${jsExample}${safariEnvFlag}`), '\n');
+          Logger.info('To run an example test (ecosia.js), run:');
+          Logger.info('  Chrome: ', colors.cyan(`${jsExample}${chromeEnvFlag}`), '\n');
+          Logger.info('  Safari: ', colors.cyan(`${jsExample}${safariEnvFlag}`), '\n');
         }
       }
     }
@@ -1010,11 +1013,11 @@ export class NightwatchInit {
 
   postConfigInstructions(answers: ConfigGeneratorAnswers) {
     if (answers.seleniumServer && this.otherInfo.javaNotInstalled) {
-      Logger.error('Java Development Kit (minimum v7) is required to run selenium-server locally. Download from here:');
-      Logger.error(colors.cyan('  https://www.oracle.com/technetwork/java/javase/downloads/index.html'), '\n');
+      Logger.info('Java Development Kit (minimum v7) is required to run selenium-server locally. Download from here:');
+      Logger.info(colors.cyan('  https://www.oracle.com/technetwork/java/javase/downloads/index.html'), '\n');
     }
 
-    Logger.error('Happy Testing!!!');
+    Logger.info('Happy Testing!');
   }
 
   pushAnonymousMetrics(answers: ConfigGeneratorAnswers) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,4 +2,14 @@ export default class Logger {
   static error(...msgs: string[]) {
     console.error(...msgs);
   }
+
+  static info(...msgs: string[]) {
+    // eslint-disable-next-line no-console
+    console.info(...msgs);
+  }
+
+  static warn(...msgs: string[]) {
+    // eslint-disable-next-line no-console
+    console.warn(...msgs);
+  }
 }

--- a/test/e2e_tests/init.js
+++ b/test/e2e_tests/init.js
@@ -8,19 +8,37 @@ const nock = require('nock');
 
 const rootDir = path.join(process.cwd(), 'test_output');
 
-describe('e2e tests for init', () => {
-  before(() => {
+function mockLoger(consoleOutput) {
+  mockery.registerMock(
+    './logger',
+    class {
+      static error(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static info(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static warn(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+    }
+  );
+}
+
+
+describe('e2e tests for init', function () {
+  before(function()  {
     if (!nock.isActive()) {
       nock.activate();
     }
   });
 
-  after(() => {
+  after(function() {
     nock.cleanAll();
     nock.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     rmDirSync(rootDir);
 
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
@@ -36,22 +54,15 @@ describe('e2e tests for init', () => {
     }
   });
 
-  afterEach(() => {
+  afterEach(function() {
     mockery.deregisterAll();
     mockery.resetCache();
     mockery.disable();
   });
 
-  test('with js-nightwatch-local', async () => {
+  it('with js-nightwatch-local', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -92,11 +103,11 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, []);
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -154,13 +165,16 @@ describe('e2e tests for init', () => {
 
     // Test Packages and webdrivers installed
     if (process.platform === 'darwin') {
-      assert.strictEqual(commandsExecuted.length, 3);
+      assert.strictEqual(commandsExecuted.length, 4);
       assert.strictEqual(commandsExecuted[2], 'sudo safaridriver --enable');
+      assert.strictEqual(commandsExecuted[3], 'npx nightwatch --version');
     } else {
-      assert.strictEqual(commandsExecuted.length, 2);
+      assert.strictEqual(commandsExecuted.length, 3);
+      assert.strictEqual(commandsExecuted[2], 'npx nightwatch --version');
     }
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install chromedriver --save-dev');
+
 
     // Test examples copied
     const examplesPath = path.join(rootDir, answers.examplesLocation);
@@ -179,10 +193,9 @@ describe('e2e tests for init', () => {
     assert.strictEqual(output.includes('Success! Generated some example files at \'nightwatch\'.'), true);
     assert.strictEqual(output.includes('Generating template files...'), true);
     assert.strictEqual(output.includes(`Success! Generated some templates files at '${path.join('nightwatch', 'templates')}'.`), true);
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS'), true);
+    assert.strictEqual(output.includes('✨ SETUP COMPLETE'), true);
+    assert.strictEqual(output.includes('💬 Join our Discord community to find answers to your issues or queries.'), true);
+    assert.strictEqual(output.includes('RUN EXAMPLE TESTS'), true);
     assert.strictEqual(output.includes('First, change directory to the root dir of your project:'), true);
     assert.strictEqual(output.includes('cd test_output'), true);
     assert.strictEqual(
@@ -199,16 +212,9 @@ describe('e2e tests for init', () => {
 
   });
 
-  test('with js-cucumber-remote', async () => {
+  it('with js-cucumber-remote', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -251,11 +257,11 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, []);
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -301,7 +307,7 @@ describe('e2e tests for init', () => {
     assert.deepEqual(Object.keys(config.test_settings), ['default', 'remote', 'remote.chrome', 'remote.edge']);
 
     // Test Packages and webdrivers installed
-    assert.strictEqual(commandsExecuted.length, 2);
+    assert.strictEqual(commandsExecuted.length, 3);
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install @cucumber/cucumber --save-dev');
 
@@ -324,9 +330,7 @@ describe('e2e tests for init', () => {
       ),
       true
     );
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
+
     assert.strictEqual(output.includes('IMPORTANT'), true);
     assert.strictEqual(output.includes('To run tests on your remote device, please set the host and port property in your nightwatch.conf.js file.'), true);
     assert.strictEqual(output.includes('These can be located at:'), true);
@@ -334,7 +338,6 @@ describe('e2e tests for init', () => {
     assert.strictEqual(output.includes('- REMOTE_USERNAME'), true);
     assert.strictEqual(output.includes('- REMOTE_ACCESS_KEY'), true);
     assert.strictEqual(output.includes('(.env files are also supported)'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS'), true);
     assert.strictEqual(output.includes('First, change directory to the root dir of your project:'), true);
     assert.strictEqual(output.includes('cd test_output'), true);
     assert.strictEqual(output.includes('To run your tests with CucumberJS, simply run:'), true);
@@ -351,16 +354,9 @@ describe('e2e tests for init', () => {
 
   });
 
-  test('with js-mocha-both', async () => {
+  it('with js-mocha-both', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -405,11 +401,11 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, []);
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -479,7 +475,7 @@ describe('e2e tests for init', () => {
     }
 
     // Test Packages and webdrivers installed
-    assert.strictEqual(commandsExecuted.length, 2);
+    assert.strictEqual(commandsExecuted.length, 3);
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install chromedriver --save-dev');
 
@@ -503,14 +499,10 @@ describe('e2e tests for init', () => {
     }
     assert.strictEqual(output.includes('Generating example files...'), true);
     assert.strictEqual(output.includes('Success! Generated some example files at \'nightwatch\'.'), true);
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
     assert.strictEqual(output.includes('Please set the credentials required to run tests on your cloud provider'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_USERNAME'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_ACCESS_KEY'), true);
     assert.strictEqual(output.includes('(.env files are also supported)'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS'), true);
     assert.strictEqual(output.includes('First, change directory to the root dir of your project:'), true);
     assert.strictEqual(output.includes('cd test_output'), true);
     assert.strictEqual(output.includes(`npx nightwatch .${path.sep}${path.join('nightwatch', 'examples')}`), true);
@@ -524,16 +516,9 @@ describe('e2e tests for init', () => {
 
   });
 
-  test('with ts-nightwatch-remote-mobile', async () => {
+  it('with ts-nightwatch-remote-mobile', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -580,11 +565,11 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, []);
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -633,13 +618,14 @@ describe('e2e tests for init', () => {
     ]);
 
     // Test Packages and webdrivers installed
-    assert.strictEqual(commandsExecuted.length, 6);
+    assert.strictEqual(commandsExecuted.length, 7);
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install typescript --save-dev');
     assert.strictEqual(commandsExecuted[2], 'npm install @types/nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[3], 'npm install ts-node --save-dev');
     assert.strictEqual(commandsExecuted[4], 'npm install @nightwatch/mobile-helper --save-dev');
     assert.strictEqual(commandsExecuted[5], 'npx tsc --init');
+    assert.strictEqual(commandsExecuted[6], 'npx nightwatch --version');
 
     // Test examples copied
     const examplesPath = path.join(rootDir, answers.examplesLocation);
@@ -663,14 +649,11 @@ describe('e2e tests for init', () => {
       output.includes('Success! Generated some example files at \'nightwatch\'.'),
       true
     );
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
+
     assert.strictEqual(output.includes('Please set the credentials required to run tests on your cloud provider'), true);
     assert.strictEqual(output.includes('- SAUCE_USERNAME'), true);
     assert.strictEqual(output.includes('- SAUCE_ACCESS_KEY'), true);
     assert.strictEqual(output.includes('(.env files are also supported)'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS'), true);
     assert.strictEqual(output.includes('First, change directory to the root dir of your project:'), true);
     assert.strictEqual(output.includes('cd test_output'), true);
     assert.strictEqual(output.includes(`npx nightwatch .${path.sep}${path.join('nightwatch')} --env saucelabs.chrome`), true);
@@ -686,16 +669,9 @@ describe('e2e tests for init', () => {
 
   });
 
-  test('with ts-mocha-both-browserstack-mobile and non-default config', async () => {
+  it('with ts-mocha-both-browserstack-mobile and non-default config', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -773,13 +749,13 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, []);
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
 
     const configFileName = 'new-config.conf.js';
     const configPath = path.join(rootDir, configFileName);
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       nightwatchInit.otherInfo.nonDefaultConfigName = configFileName;
 
       return configPath;
@@ -865,7 +841,7 @@ describe('e2e tests for init', () => {
     }
 
     // Test Packages and webdrivers installed
-    assert.strictEqual(commandsExecuted.length, 7);
+    assert.strictEqual(commandsExecuted.length, 8);
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install typescript --save-dev');
     assert.strictEqual(commandsExecuted[2], 'npm install @types/nightwatch --save-dev');
@@ -899,14 +875,10 @@ describe('e2e tests for init', () => {
       output.includes('Examples already exists at \'nightwatch\'. Skipping...'),
       true
     );
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
     assert.strictEqual(output.includes('Please set the credentials required to run tests on your cloud provider'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_USERNAME'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_ACCESS_KEY'), true);
     assert.strictEqual(output.includes('(.env files are also supported)'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS'), true);
     assert.strictEqual(output.includes('First, change directory to the root dir of your project:'), true);
     assert.strictEqual(output.includes('cd test_output'), true);
     assert.strictEqual(output.includes(`npx nightwatch .${path.sep}${path.join('nightwatch')} --config new-config.conf.js`), true);
@@ -941,16 +913,9 @@ describe('e2e tests for init', () => {
 
   });
 
-  test('with yes and browser flag', async () => {
+  it('with yes and browser flag', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -989,7 +954,7 @@ describe('e2e tests for init', () => {
     });
 
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -1047,7 +1012,7 @@ describe('e2e tests for init', () => {
     ]);
 
     // Test Packages and webdrivers installed
-    assert.strictEqual(commandsExecuted.length, 5);
+    assert.strictEqual(commandsExecuted.length, 6);
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install @nightwatch/selenium-server --save-dev');
     assert.strictEqual(commandsExecuted[2], 'java -version');
@@ -1070,14 +1035,10 @@ describe('e2e tests for init', () => {
     assert.strictEqual(output.includes('Installing webdriver for Chrome (chromedriver)...'), true);
     assert.strictEqual(output.includes('Generating example files...'), true);
     assert.strictEqual(output.includes('Success! Generated some example files at \'nightwatch\'.'), true);
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
     assert.strictEqual(output.includes('Please set the credentials required to run tests on your cloud provider'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_USERNAME'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_ACCESS_KEY'), true);
     assert.strictEqual(output.includes('(.env files are also supported)'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS'), true);
     assert.strictEqual(output.includes('First, change directory to the root dir of your project:'), true);
     assert.strictEqual(output.includes('cd test_output'), true);
     assert.strictEqual(output.includes(`npx nightwatch .${path.sep}${path.join('nightwatch', 'examples')}`), true);
@@ -1092,16 +1053,9 @@ describe('e2e tests for init', () => {
     rmDirSync(rootDir);
   });
 
-  test('with yes, browser and mobile flag', async () => {
+  it('with yes, browser and mobile flag', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1165,7 +1119,7 @@ describe('e2e tests for init', () => {
     });
 
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -1244,10 +1198,10 @@ describe('e2e tests for init', () => {
 
     // Test Packages and webdrivers installed
     if (process.platform === 'darwin') {
-      assert.strictEqual(commandsExecuted.length, 5);
+      assert.strictEqual(commandsExecuted.length, 6);
       assert.strictEqual(commandsExecuted[4], 'sudo safaridriver --enable');
     } else {
-      assert.strictEqual(commandsExecuted.length, 4);
+      assert.strictEqual(commandsExecuted.length, 5);
     }
     assert.strictEqual(commandsExecuted[0], 'npm install nightwatch --save-dev');
     assert.strictEqual(commandsExecuted[1], 'npm install @nightwatch/mobile-helper --save-dev');
@@ -1271,14 +1225,10 @@ describe('e2e tests for init', () => {
     if (process.platform === 'darwin') {assert.strictEqual(output.includes('Enabling safaridriver...'), true)}
     assert.strictEqual(output.includes('Generating example files...'), true);
     assert.strictEqual(output.includes('Success! Generated some example files at \'nightwatch\'.'), true);
-    assert.strictEqual(output.includes('Nightwatch setup complete!!'), true);
-    assert.strictEqual(output.includes('Join our Discord community and instantly find answers to your issues or queries.'), true);
-    assert.strictEqual(output.includes('Visit our GitHub page to report bugs or raise feature requests:'), true);
     assert.strictEqual(output.includes('Please set the credentials required to run tests on your cloud provider'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_USERNAME'), true);
     assert.strictEqual(output.includes('- BROWSERSTACK_ACCESS_KEY'), true);
     assert.strictEqual(output.includes('(.env files are also supported)'), true);
-    assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS\n'), false);
 
     assert.strictEqual(output.includes('RUN NIGHTWATCH TESTS ON MOBILE'), true);
     assert.strictEqual(output.includes('Android setup failed...'), true);
@@ -1303,16 +1253,9 @@ describe('e2e tests for init', () => {
     rmDirSync(rootDir);
   });
 
-  test('generate-config with js-nightwatch-local and seleniumServer false', async () => {
+  it('generate-config with js-nightwatch-local and seleniumServer false', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1354,11 +1297,11 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, {'generate-config': true});
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -1430,22 +1373,14 @@ describe('e2e tests for init', () => {
     assert.strictEqual(output.includes('Success! Configuration file generated at:'), true);
     assert.strictEqual(output.includes('Installing webdriver for Chrome (chromedriver)...'), true);
     if (process.platform === 'darwin') {assert.strictEqual(output.includes('Enabling safaridriver...'), true)}
-    assert.strictEqual(output.includes('Happy Testing!!!'), true);
 
     rmDirSync(rootDir);
 
   });
 
-  test('generate-config with ts-nightwatch-both', async () => {
+  it('generate-config with ts-nightwatch-both', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1488,11 +1423,11 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, {'generate-config': true});
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
@@ -1561,21 +1496,13 @@ describe('e2e tests for init', () => {
       true
     );
     assert.strictEqual(output.includes('Installing webdriver for Firefox (geckodriver)...'), true);
-    assert.strictEqual(output.includes('Happy Testing!!!'), true);
 
     rmDirSync(rootDir);
   });
 
-  test('make sure we send analytics data if allowAnalytics is set to true', async (done) => {
+  it('make sure we send analytics data if allowAnalytics is set to true', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1623,35 +1550,30 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, {'generate-config': true});
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
 
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
     await nightwatchInit.run();
-    
-    setTimeout(() => {
-      assert.ok(scope.isDone());
-      done();
-    }, 0);
 
-    rmDirSync(rootDir);
+    new Promise(resolve => {
+      setTimeout(function() {
+        assert.ok(scope.isDone());
+        resolve();
+      }, 0);
+
+      rmDirSync(rootDir);
+    });
   });
 
-  test('make sure we do not send analytics data if allowAnalytics is set to false', async (done) => {
+  it('make sure we do not send analytics data if allowAnalytics is set to false', async function () {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1681,19 +1603,17 @@ describe('e2e tests for init', () => {
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, {'generate-config': true});
 
-    nightwatchInit.askQuestions = () => {
+    nightwatchInit.askQuestions = function() {
       return answers;
     };
 
     const configPath = path.join(rootDir, 'nightwatch.conf.js');
-    nightwatchInit.getConfigDestPath = () => {
+    nightwatchInit.getConfigDestPath = function() {
       return configPath;
     };
 
     await nightwatchInit.run();
 
     rmDirSync(rootDir);
-
-    done();
   });
 });

--- a/test/e2e_tests/init.js
+++ b/test/e2e_tests/init.js
@@ -8,7 +8,7 @@ const nock = require('nock');
 
 const rootDir = path.join(process.cwd(), 'test_output');
 
-function mockLoger(consoleOutput) {
+function mockLogger(consoleOutput) {
   mockery.registerMock(
     './logger',
     class {
@@ -62,7 +62,7 @@ describe('e2e tests for init', function () {
 
   it('with js-nightwatch-local', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -214,7 +214,7 @@ describe('e2e tests for init', function () {
 
   it('with js-cucumber-remote', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -358,7 +358,7 @@ describe('e2e tests for init', function () {
 
   it('with js-mocha-both', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -520,7 +520,7 @@ describe('e2e tests for init', function () {
 
   it('with ts-nightwatch-remote-mobile', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -673,7 +673,7 @@ describe('e2e tests for init', function () {
 
   it('with ts-mocha-both-browserstack-mobile and non-default config', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -917,7 +917,7 @@ describe('e2e tests for init', function () {
 
   it('with yes and browser flag', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1057,7 +1057,7 @@ describe('e2e tests for init', function () {
 
   it('with yes, browser and mobile flag', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1257,7 +1257,7 @@ describe('e2e tests for init', function () {
 
   it('generate-config with js-nightwatch-local and seleniumServer false', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1382,7 +1382,7 @@ describe('e2e tests for init', function () {
 
   it('generate-config with ts-nightwatch-both', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1504,7 +1504,7 @@ describe('e2e tests for init', function () {
 
   it('make sure we send analytics data if allowAnalytics is set to true', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1548,7 +1548,7 @@ describe('e2e tests for init', function () {
           value: []
         };
       });
-    
+
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, {'generate-config': true});
 
@@ -1575,7 +1575,7 @@ describe('e2e tests for init', function () {
 
   it('make sure we do not send analytics data if allowAnalytics is set to false', async function () {
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     const commandsExecuted = [];
     mockery.registerMock('child_process', {
@@ -1601,7 +1601,7 @@ describe('e2e tests for init', function () {
       .reply(204, (uri, requestBody) => {
         assert.fail();
       });
-    
+
     const {NightwatchInit} = require('../../lib/init');
     const nightwatchInit = new NightwatchInit(rootDir, {'generate-config': true});
 

--- a/test/unit_tests/testIndex.js
+++ b/test/unit_tests/testIndex.js
@@ -172,7 +172,7 @@ describe('index tests',  function () {
     const index = require('../../lib/index');
     await index.run();
     const output = consoleOutput.toString();
-    console.log(consoleOutput)
+
     assert.strictEqual(
       output.includes(`We\'ve updated this onboarding tool: ${VERSION} -> 1.0.2. To get the latest experience, run: npm init nightwatch@latest`),
       true

--- a/test/unit_tests/testIndex.js
+++ b/test/unit_tests/testIndex.js
@@ -5,9 +5,26 @@ const nock = require('nock');
 
 const VERSION = process.env.npm_package_version;
 
-describe('index tests', () => {
+function mockLoger(consoleOutput) {
+  mockery.registerMock(
+    './logger',
+    class {
+      static error(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static info(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static warn(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+    }
+  );
+}
 
-  beforeEach(() => {
+describe('index tests',  function () {
+
+  beforeEach( function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     if (!nock.isActive()) {
       nock.activate();
@@ -22,7 +39,7 @@ describe('index tests', () => {
     
   });
 
-  afterEach(() => {
+  afterEach( function () {
     mockery.deregisterAll();
     mockery.resetCache();
     mockery.disable();
@@ -30,18 +47,11 @@ describe('index tests', () => {
     nock.restore();
   });
   
-  test('should not give suggestion when right args are passed ', async () => {
+  it('should not give suggestion when right args are passed ', async function () {
     process.argv = ['node', 'filename.js', '--browser=chrome', '--browser=safari', 'args'];
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -68,7 +78,7 @@ describe('index tests', () => {
     });
 
     mockery.registerMock(child_process, {
-      execSync: () => {
+      execSync:  function () {
         return true;
       }
     });
@@ -83,18 +93,11 @@ describe('index tests', () => {
     );
   });
 
-  test('should give suggestion when wrong args are passed ', async () => {
+  it('should give suggestion when wrong args are passed ', async function () {
     process.argv = ['node', 'filename.js', '--browsers=chrome', '--browsers=safari'];
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -106,7 +109,7 @@ describe('index tests', () => {
     });
 
     mockery.registerMock(child_process, {
-      execSync: () => {
+      execSync:  function () {
         return true;
       }
     });
@@ -121,18 +124,11 @@ describe('index tests', () => {
     );
   });
 
-  test('should give warning to run with latest package when using older version', async () => {
+  it('should give warning to run with latest package when using older version', async function () {
     process.argv = ['node', 'filename.js', '--browser=chrome', '--browser=safari', 'args'];
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -159,7 +155,7 @@ describe('index tests', () => {
     });
 
     mockery.registerMock(child_process, {
-      execSync: () => {
+      execSync:  function () {
         return true;
       }
     });
@@ -176,8 +172,9 @@ describe('index tests', () => {
     const index = require('../../lib/index');
     await index.run();
     const output = consoleOutput.toString();
+    console.log(consoleOutput)
     assert.strictEqual(
-      output.includes(`We\'ve updated this onboarding tool. ${VERSION} -> 1.0.2. To get the latest experience, run: npm init nightwatch@latest`),
+      output.includes(`We\'ve updated this onboarding tool: ${VERSION} -> 1.0.2. To get the latest experience, run: npm init nightwatch@latest`),
       true
     );
   });

--- a/test/unit_tests/testIndex.js
+++ b/test/unit_tests/testIndex.js
@@ -5,7 +5,7 @@ const nock = require('nock');
 
 const VERSION = process.env.npm_package_version;
 
-function mockLoger(consoleOutput) {
+function mockLogger(consoleOutput) {
   mockery.registerMock(
     './logger',
     class {
@@ -36,7 +36,7 @@ describe('index tests',  function () {
           latest: VERSION
         }
       });
-    
+
   });
 
   afterEach( function () {
@@ -46,12 +46,12 @@ describe('index tests',  function () {
     nock.cleanAll();
     nock.restore();
   });
-  
+
   it('should not give suggestion when right args are passed ', async function () {
     process.argv = ['node', 'filename.js', '--browser=chrome', '--browser=safari', 'args'];
 
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -97,7 +97,7 @@ describe('index tests',  function () {
     process.argv = ['node', 'filename.js', '--browsers=chrome', '--browsers=safari'];
 
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -128,7 +128,7 @@ describe('index tests',  function () {
     process.argv = ['node', 'filename.js', '--browser=chrome', '--browser=safari', 'args'];
 
     const consoleOutput = [];
-    mockLoger(consoleOutput);
+    mockLogger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {

--- a/test/unit_tests/testInit.js
+++ b/test/unit_tests/testInit.js
@@ -21,19 +21,19 @@ function mockLoger(consoleOutput) {
 }
 
 const rootDir = path.join(process.cwd(), 'test_output');
-describe('init tests', () => {
-  describe('test askQuestions', () => {
-    beforeEach(() => {
+describe('init tests', function() {
+  describe('test askQuestions', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('if answers passed to inquirer contains rootDir and onlyConfig by default', async () => {
+    it('if answers passed to inquirer contains rootDir and onlyConfig by default', async function() {
       mockery.registerMock('inquirer', {
         async prompt(questions, answers) {
           return answers;
@@ -51,7 +51,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['browsers'], undefined);
     });
 
-    test('if answers passed to inquirer also contains browsers and mobile when flags passed', async () => {
+    it('if answers passed to inquirer also contains browsers and mobile when flags passed', async function() {
       mockery.registerMock('inquirer', {
         async prompt(questions, answers) {
           return answers;
@@ -72,7 +72,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['mobile'], true);
     });
 
-    test('if answers passed to inquirer contains correct property when mobile flag passed with wrong type', async () => {
+    it('if answers passed to inquirer contains correct property when mobile flag passed with wrong type', async function() {
       mockery.registerMock('inquirer', {
         async prompt(questions, answers) {
           return answers;
@@ -93,18 +93,18 @@ describe('init tests', () => {
     });
   });
 
-  describe('test refineAnswers', () => {
-    beforeEach(() => {
+  describe('test refineAnswers', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('with just both in answers', () => {
+    it('with just both in answers', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => false
       });
@@ -141,7 +141,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['examplesLocation'], 'nightwatch');
     });
 
-    test('with local, seleniumServer and no mobile and testsLocation (non-existent) in answers', () => {
+    it('with local, seleniumServer and no mobile and testsLocation (non-existent) in answers', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => false
       });
@@ -183,7 +183,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['seleniumServer'], true);
     });
 
-    test('with local and mobile with no mobileBrowsers', () => {
+    it('with local and mobile with no mobileBrowsers', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => false
       });
@@ -231,7 +231,7 @@ describe('init tests', () => {
       }
     });
 
-    test('with local and mobile with mobile flag', () => {
+    it('with local and mobile with mobile flag', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => false
       });
@@ -275,7 +275,7 @@ describe('init tests', () => {
       }
     });
 
-    test('with remote (browserstack) and testsLocation (exist but empty) in answers', () => {
+    it('with remote (browserstack) and testsLocation (exist but empty) in answers', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => true,
         readdirSync: () => []
@@ -318,7 +318,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['examplesLocation'], 'nightwatch');
     });
 
-    test('with remote (saucelabs) and mobile and testsLocation (exist and non-empty) in answers', () => {
+    it('with remote (saucelabs) and mobile and testsLocation (exist and non-empty) in answers', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => true,
         readdirSync: () => ['file.txt']
@@ -362,7 +362,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['examplesLocation'], 'nightwatch');
     });
 
-    test('with remote (other) in answers and onlyConfig flag and mobile with mobile flag', () => {
+    it('with remote (other) in answers and onlyConfig flag and mobile with mobile flag', function() {
       mockery.registerMock('node:fs', {
         existsSync: () => false
       });
@@ -402,7 +402,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['remoteEnv'].access_key, 'REMOTE_ACCESS_KEY');
     });
 
-    test('with both (remote - other) and cucumber runner and seleniumServer false', () => {
+    it('with both (remote - other) and cucumber runner and seleniumServer false', function() {
       const {NightwatchInit} = require('../../lib/init');
       const nightwatchInit = new NightwatchInit(rootDir, []);
 
@@ -444,7 +444,7 @@ describe('init tests', () => {
       assert.strictEqual(answers['examplesLocation'], 'nightwatch');
     });
 
-    test('with both (remote - other) and mobile with mobile flag', () => {
+    it('with both (remote - other) and mobile with mobile flag', function() {
       const {NightwatchInit} = require('../../lib/init');
       const nightwatchInit = new NightwatchInit(rootDir, []);
 
@@ -492,18 +492,18 @@ describe('init tests', () => {
     });
   });
 
-  describe('test identifyPackagesToInstall', () => {
-    beforeEach(() => {
+  describe('test identifyPackagesToInstall', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('correct packages are installed with ts-mocha-seleniumServer-mobile', () => {
+    it('correct packages are installed with ts-mocha-seleniumServer-mobile', function() {
       mockery.registerMock('node:fs', {
         readFileSync(path, encoding) {
           return `{
@@ -534,7 +534,7 @@ describe('init tests', () => {
       assert.strictEqual(packagesToInstall.includes('@nightwatch/mobile-helper'), true);
     });
 
-    test('correct packages are installed with js-cucumber', () => {
+    it('correct packages are installed with js-cucumber', function() {
       mockery.registerMock('node:fs', {
         readFileSync(path, encoding) {
           return `{
@@ -563,7 +563,7 @@ describe('init tests', () => {
       assert.strictEqual(packagesToInstall.includes('@nightwatch/mobile-helper'), false);
     });
 
-    test('correct packages are installed with ts-cucumber-seleniumServer without initial packages', () => {
+    it('correct packages are installed with ts-cucumber-seleniumServer without initial packages', function() {
       mockery.registerMock('node:fs', {
         readFileSync(path, encoding) {
           return '{}';
@@ -589,18 +589,18 @@ describe('init tests', () => {
     });
   });
 
-  describe('test installPackages', () => {
-    beforeEach(() => {
+  describe('test installPackages', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('packages are installed correctly with correct output', () => {
+    it('packages are installed correctly with correct output', function() {
       const consoleOutput = [];
       mockLoger(consoleOutput);
 
@@ -637,18 +637,18 @@ describe('init tests', () => {
     });
   });
 
-  describe('test setupTypesript', () => {
-    beforeEach(() => {
+  describe('test setupTypesript', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('with both tsconfig not present', () => {
+    it('with both tsconfig not present', function() {
       let nwTsconfigCopied = false;
 
       mockery.registerMock('node:fs', {
@@ -679,7 +679,7 @@ describe('init tests', () => {
       assert.strictEqual(nightwatchInit.otherInfo.tsOutDir, '');
     });
 
-    test('with both tsconfig already present', () => {
+    it('with both tsconfig already present', function() {
       let nwTsconfigCopied = false;
 
       mockery.registerMock('node:fs', {
@@ -708,7 +708,7 @@ describe('init tests', () => {
       assert.strictEqual(nightwatchInit.otherInfo.tsOutDir, '');
     });
 
-    test('with tsconfig.nightwatch.json already present', () => {
+    it('with tsconfig.nightwatch.json already present', function() {
       let nwTsconfigCopied = false;
 
       mockery.registerMock('node:fs', {
@@ -744,18 +744,18 @@ describe('init tests', () => {
     });
   });
 
-  describe('test getConfigDestPath', () => {
-    beforeEach(() => {
+  describe('test getConfigDestPath', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('if config file is not already present', async () => {
+    it('if config file is not already present', async function() {
       const consoleOutput = [];
       mockLoger(consoleOutput);
 
@@ -779,7 +779,7 @@ describe('init tests', () => {
       assert.strictEqual(nightwatchInit.otherInfo.usingESM, false);
     });
 
-    test('if config file is already present and overwrite in prompt', async () => {
+    it('if config file is already present and overwrite in prompt', async function() {
       const consoleOutput = [];
       mockLoger(consoleOutput);
 
@@ -809,7 +809,7 @@ describe('init tests', () => {
       assert.strictEqual(nightwatchInit.otherInfo.usingESM, false);
     });
 
-    test('if config file is already present and new file in prompt', async () => {
+    it('if config file is already present and new file in prompt', async function() {
       const consoleOutput = [];
       mockLoger(consoleOutput);
 
@@ -841,16 +841,9 @@ describe('init tests', () => {
       assert.strictEqual(nightwatchInit.otherInfo.usingESM, false);
     });
 
-    test('if config file is not already present (ESM)', async () => {
+    it('if config file is not already present (ESM)', async function() {
       const consoleOutput = [];
-      mockery.registerMock(
-        './logger',
-        class {
-          static error(...msgs) {
-            consoleOutput.push(...msgs);
-          }
-        }
-      );
+      mockLoger(consoleOutput);
 
       mockery.registerMock('node:fs', {
         existsSync(path) {
@@ -872,16 +865,9 @@ describe('init tests', () => {
       assert.strictEqual(nightwatchInit.otherInfo.usingESM, true);
     });
 
-    test('if config file is already present and new file in prompt (ESM)', async () => {
+    it('if config file is already present and new file in prompt (ESM)', async function() {
       const consoleOutput = [];
-      mockery.registerMock(
-        './logger',
-        class {
-          static error(...msgs) {
-            consoleOutput.push(...msgs);
-          }
-        }
-      );
+      mockLoger(consoleOutput);
 
       mockery.registerMock('node:fs', {
         existsSync(path) {
@@ -917,24 +903,19 @@ describe('init tests', () => {
     });
   });
 
-  describe('test generateConfig', () => {
-    beforeEach(() => {
+  describe('test generateConfig', function() {
+    beforeEach(function() {
       mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     });
 
-    afterEach(() => {
+    afterEach(function() {
       mockery.deregisterAll();
       mockery.resetCache();
       mockery.disable();
     });
 
-    test('generateConfig with js and without testsLocation and examplesLocation', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js and without testsLocation and examplesLocation', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'js',
@@ -964,13 +945,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js (local with mobile) and same testsLocation and examplesLocation', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js (local with mobile) and same testsLocation and examplesLocation', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'js',
@@ -1012,13 +988,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js (local with mobile) with mobile flag', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js (local with mobile) with mobile flag', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'js',
@@ -1060,13 +1031,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js with different testsLocation and examplesLocation', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js with different testsLocation and examplesLocation', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'js',
@@ -1119,13 +1085,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js with cucumber and same testsLocation and examplesLocation', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js with cucumber and same testsLocation and examplesLocation', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'js',
@@ -1181,13 +1142,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js with cucumber (both and mobile with mobile flag) and different testsLocation and examplesLocation', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js with cucumber (both and mobile with mobile flag) and different testsLocation and examplesLocation', function() {
+      mockLoger([]);
 
       // can be converted to sauce once we have sauce mobile configs
       const answers = {
@@ -1248,13 +1204,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with ts (remote with mobile) with testsLocation and examplesLocation', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with ts (remote with mobile) with testsLocation and examplesLocation', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'ts',
@@ -1310,13 +1261,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js with allowAnonymousMetrics set to false', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js with allowAnonymousMetrics set to false', function() {
+      mockLoger([]);
 
       mockery.registerMock(
         'uuid',
@@ -1351,13 +1297,8 @@ describe('init tests', () => {
       fs.unlinkSync('test_config.conf.js');
     });
 
-    test('generateConfig with js with allowAnonymousMetrics set to true', () => {
-      mockery.registerMock(
-        './logger',
-        class {
-          static error() {}
-        }
-      );
+    it('generateConfig with js with allowAnonymousMetrics set to true', function() {
+      mockLoger([]);
 
       const answers = {
         language: 'js',

--- a/test/unit_tests/testInit.js
+++ b/test/unit_tests/testInit.js
@@ -3,8 +3,24 @@ const mockery = require('mockery');
 const fs = require('node:fs');
 const path = require('path');
 
-const rootDir = path.join(process.cwd(), 'test_output');
+function mockLoger(consoleOutput) {
+  mockery.registerMock(
+    './logger',
+    class {
+      static error(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static info(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static warn(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+    }
+  );
+}
 
+const rootDir = path.join(process.cwd(), 'test_output');
 describe('init tests', () => {
   describe('test askQuestions', () => {
     beforeEach(() => {
@@ -586,14 +602,7 @@ describe('init tests', () => {
 
     test('packages are installed correctly with correct output', () => {
       const consoleOutput = [];
-      mockery.registerMock(
-        './logger',
-        class {
-          static error(...msgs) {
-            consoleOutput.push(...msgs);
-          }
-        }
-      );
+      mockLoger(consoleOutput);
 
       const commandsExecuted = [];
       mockery.registerMock('child_process', {
@@ -748,14 +757,7 @@ describe('init tests', () => {
 
     test('if config file is not already present', async (done) => {
       const consoleOutput = [];
-      mockery.registerMock(
-        './logger',
-        class {
-          static error(...msgs) {
-            consoleOutput.push(...msgs);
-          }
-        }
-      );
+      mockLoger(consoleOutput);
 
       mockery.registerMock('node:fs', {
         existsSync(path) {
@@ -776,14 +778,7 @@ describe('init tests', () => {
 
     test('if config file is already present and overwrite in prompt', async (done) => {
       const consoleOutput = [];
-      mockery.registerMock(
-        './logger',
-        class {
-          static error(...msgs) {
-            consoleOutput.push(...msgs);
-          }
-        }
-      );
+      mockLoger(consoleOutput);
 
       mockery.registerMock('node:fs', {
         existsSync(path) {
@@ -811,14 +806,7 @@ describe('init tests', () => {
 
     test('if config file is already present and new file in prompt', async (done) => {
       const consoleOutput = [];
-      mockery.registerMock(
-        './logger',
-        class {
-          static error(...msgs) {
-            consoleOutput.push(...msgs);
-          }
-        }
-      );
+      mockLoger(consoleOutput);
 
       mockery.registerMock('node:fs', {
         existsSync(path) {
@@ -1276,9 +1264,7 @@ describe('init tests', () => {
       nightwatchInit.generateConfig(answers, 'test_config.conf.js');
       const config = require('../../test_config.conf.js');
 
-      assert.strictEqual(config.usage_analytics.enabled, false);
-      assert.strictEqual(config.usage_analytics.log_path, './logs/analytics');
-      assert.strictEqual(config.usage_analytics.client_id, '3141-5926-5358-9793');
+      assert.strictEqual(typeof config.usage_analytics, 'undefined');
 
       fs.unlinkSync('test_config.conf.js');
     });

--- a/test/unit_tests/testInitializeNodeProject.js
+++ b/test/unit_tests/testInitializeNodeProject.js
@@ -18,18 +18,18 @@ function mockLoger(consoleOutput) {
   );
 }
 
-describe('test initializeNodeProject', () => {
-  beforeEach(() => {
+describe('test initializeNodeProject', function () {
+  beforeEach(function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
   });
 
-  afterEach(() => {
+  afterEach(function () {
     mockery.deregisterAll();
     mockery.resetCache();
     mockery.disable();
   });
 
-  test('when rootDir exists', () => {
+  it('when rootDir exists', function () {
     const consoleOutput = [];
     mockLoger(consoleOutput);
 
@@ -71,7 +71,7 @@ describe('test initializeNodeProject', () => {
     assert.strictEqual(output.includes('Initializing a new NPM project'), true);
   });
 
-  test('when rootDir does not exists', () => {
+  it('when rootDir does not exists', function () {
     const rootDir = 'someDirPath';
 
     const consoleOutput = [];

--- a/test/unit_tests/testInitializeNodeProject.js
+++ b/test/unit_tests/testInitializeNodeProject.js
@@ -1,6 +1,22 @@
 const assert = require('assert');
 const mockery = require('mockery');
 
+function mockLoger(consoleOutput) {
+  mockery.registerMock(
+    './logger',
+    class {
+      static error(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static info(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static warn(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+    }
+  );
+}
 
 describe('test initializeNodeProject', () => {
   beforeEach(() => {
@@ -15,14 +31,7 @@ describe('test initializeNodeProject', () => {
 
   test('when rootDir exists', () => {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     let newDirCreated = false;
     mockery.registerMock('node:fs', {
@@ -66,14 +75,7 @@ describe('test initializeNodeProject', () => {
     const rootDir = 'someDirPath';
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     let newDirCreatedRecursively = false;
     mockery.registerMock('node:fs', {

--- a/test/unit_tests/testRootDir.js
+++ b/test/unit_tests/testRootDir.js
@@ -2,6 +2,23 @@ const path = require('path');
 const mockery = require('mockery');
 const assert = require('assert');
 
+function mockLoger(consoleOutput) {
+  mockery.registerMock(
+    './logger',
+    class {
+      static error(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static info(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static warn(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+    }
+  );
+}
+
 describe('test confirmRootDir', async () => {
   beforeEach(() => {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
@@ -15,14 +32,7 @@ describe('test confirmRootDir', async () => {
 
   test('when given root dir is confirmed', async () => {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('inquirer', {
       prompt() {
@@ -44,14 +54,7 @@ describe('test confirmRootDir', async () => {
 
   test('when given root dir is not confirmed and new path is provided', async () => {
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('inquirer', {
       prompt() {

--- a/test/unit_tests/testRootDir.js
+++ b/test/unit_tests/testRootDir.js
@@ -19,18 +19,18 @@ function mockLoger(consoleOutput) {
   );
 }
 
-describe('test confirmRootDir', async () => {
-  beforeEach(() => {
+describe('test confirmRootDir', async function () {
+  beforeEach(function () {
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
   });
 
-  afterEach(() => {
+  afterEach(function () {
     mockery.deregisterAll();
     mockery.resetCache();
     mockery.disable();
   });
 
-  test('when given root dir is confirmed', async () => {
+  it('when given root dir is confirmed', async function () {
     const consoleOutput = [];
     mockLoger(consoleOutput);
 
@@ -52,7 +52,7 @@ describe('test confirmRootDir', async () => {
     assert.strictEqual(output.includes('Current working directory is not a node project'), true);
   });
 
-  test('when given root dir is not confirmed and new path is provided', async () => {
+  it('when given root dir is not confirmed and new path is provided', async function () {
     const consoleOutput = [];
     mockLoger(consoleOutput);
 

--- a/test/unit_tests/testRun.js
+++ b/test/unit_tests/testRun.js
@@ -21,8 +21,8 @@ function mockLoger(consoleOutput) {
   );
 }
 
-describe('test run function', () => {
-  beforeEach(() => {
+describe('test run function', function () {
+  beforeEach(function () {
     this.originalProcessArgv = process.argv;
     mockery.enable({useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false});
     if (!nock.isActive()) {
@@ -38,7 +38,7 @@ describe('test run function', () => {
     
   });
 
-  afterEach(() => {
+  afterEach(function () {
     process.argv = this.originalProcessArgv;
     mockery.deregisterAll();
     mockery.resetCache();
@@ -47,7 +47,7 @@ describe('test run function', () => {
     nock.restore();
   });
 
-  test('works with no argument and package.json present', async () => {
+  it('works with no argument and package.json present', async function () {
     process.argv = ['node', 'filename.js'];
 
     mockLoger([]);
@@ -82,18 +82,11 @@ describe('test run function', () => {
     });
   });
 
-  test('works with no argument, package.json not present, and root dir empty', async () => {
+  it('works with no argument, package.json not present, and root dir empty', async function () {
     process.argv = ['node', 'filename.js'];
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('./utils', {
       isNodeProject() {
@@ -142,18 +135,11 @@ describe('test run function', () => {
     assert.strictEqual(newNodeProjectRootDir, process.cwd());
   });
 
-  test('works with no argument, package.json not present, and root dir not empty', async () => {
+  it('works with no argument, package.json not present, and root dir not empty', async function () {
     process.argv = ['node', 'filename.js'];
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('./utils', {
       isNodeProject() {
@@ -212,7 +198,7 @@ describe('test run function', () => {
     assert.strictEqual(newNodeProjectRootDir, process.cwd());
   });
 
-  test('works with many arguments, no options, and package.json present', async () => {
+  it('works with many arguments, no options, and package.json present', async function () {
     process.argv = ['node', 'filename.js', 'new-project', 'some', 'random', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
@@ -247,19 +233,12 @@ describe('test run function', () => {
     });
   });
 
-  test('works with many argument, no options, and package.json not present', async () => {
+  it('works with many argument, no options, and package.json not present', async function () {
     process.argv = ['node', 'filename.js', 'new-project', 'some', 'random', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     let newDirCreatedRecursively = false;
     mockery.registerMock('node:fs', {
@@ -302,7 +281,7 @@ describe('test run function', () => {
     assert.strictEqual(newNodeProjectRootDir, expectedRootDir);
   });
 
-  test('works with many arguments, generate-config options, and package.json present', async () => {
+  it('works with many arguments, generate-config options, and package.json present', async function () {
     process.argv = ['node', 'filename.js', 'new-project', 'random', '--generate-config', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
@@ -336,7 +315,7 @@ describe('test run function', () => {
     });
   });
 
-  test('works with many arguments, generate-config options, and package.json not present', async () => {
+  it('works with many arguments, generate-config options, and package.json not present', async function () {
     process.argv = ['node', 'filename.js', 'new-project', 'random', '--generate-config', 'args'];
 
     const origProcessExit = process.exit;
@@ -347,14 +326,7 @@ describe('test run function', () => {
     };
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -398,7 +370,7 @@ describe('test run function', () => {
     process.exit = origProcessExit;
   });
 
-  test('works with many arguments, browsers options, and package.json present', async () => {
+  it('works with many arguments, browsers options, and package.json present', async function () {
     process.argv = ['node', 'filename.js', 'new-project', 'random', '--browser=chrome', '--browser=safari', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
@@ -434,18 +406,11 @@ describe('test run function', () => {
     });
   });
 
-  test('works with no arguments, browser options without =, and package.json not present', async () => {
+  it('works with no arguments, browser options without =, and package.json not present', async function () {
     process.argv = ['node', 'filename.js', '--browser', 'chrome', '--browser', 'safari'];
 
     const consoleOutput = [];
-    mockery.registerMock(
-      './logger',
-      class {
-        static error(...msgs) {
-          consoleOutput.push(...msgs);
-        }
-      }
-    );
+    mockLoger(consoleOutput);
 
     mockery.registerMock('./utils', {
       isNodeProject() {
@@ -496,7 +461,7 @@ describe('test run function', () => {
     assert.strictEqual(newNodeProjectRootDir, process.cwd());
   });
 
-  test('works with many arguments, many options, and package.json present', async () => {
+  it('works with many arguments, many options, and package.json present', async function () {
     process.argv = ['node', 'filename.js', 'new-project', '-y', '--hello', '--there=hi', '-d', '--generate-config'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 

--- a/test/unit_tests/testRun.js
+++ b/test/unit_tests/testRun.js
@@ -4,6 +4,22 @@ const assert = require('assert');
 const nock = require('nock');
 const {extend} = require('axios/lib/utils');
 
+function mockLoger(consoleOutput) {
+  mockery.registerMock(
+    './logger',
+    class {
+      static error(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static info(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+      static warn(...msgs) {
+        consoleOutput.push(...msgs);
+      }
+    }
+  );
+}
 
 describe('test run function', () => {
   beforeEach(() => {
@@ -34,12 +50,7 @@ describe('test run function', () => {
   test('works with no argument and package.json present', async () => {
     process.argv = ['node', 'filename.js'];
 
-    mockery.registerMock(
-      './logger',
-      class {
-        static error() {}
-      }
-    );
+    mockLoger([]);
 
 
     mockery.registerMock('./utils', {
@@ -205,12 +216,7 @@ describe('test run function', () => {
     process.argv = ['node', 'filename.js', 'new-project', 'some', 'random', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
-    mockery.registerMock(
-      './logger',
-      class {
-        static error() {}
-      }
-    );
+    mockLoger([]);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -300,12 +306,7 @@ describe('test run function', () => {
     process.argv = ['node', 'filename.js', 'new-project', 'random', '--generate-config', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
-    mockery.registerMock(
-      './logger',
-      class {
-        static error() {}
-      }
-    );
+    mockLoger([]);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -401,12 +402,7 @@ describe('test run function', () => {
     process.argv = ['node', 'filename.js', 'new-project', 'random', '--browser=chrome', '--browser=safari', 'args'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
-    mockery.registerMock(
-      './logger',
-      class {
-        static error() {}
-      }
-    );
+    mockLoger([]);
 
     mockery.registerMock('node:fs', {
       existsSync() {
@@ -504,12 +500,7 @@ describe('test run function', () => {
     process.argv = ['node', 'filename.js', 'new-project', '-y', '--hello', '--there=hi', '-d', '--generate-config'];
     const expectedRootDir = path.join(process.cwd(), 'new-project');
 
-    mockery.registerMock(
-      './logger',
-      class {
-        static error() {}
-      }
-    );
+    mockLoger([]);
 
     mockery.registerMock('node:fs', {
       existsSync() {


### PR DESCRIPTION
Renamed most of the prompts to match a more active voice and tone in order to simplify the onboarding process overall. This is also according to our own documentation [style guide](https://nightwatchjs.org/guide/contributing/styleguide.html), namely:

- Use active voice. Think of it as you being the guiding teacher to the user
- Be in the present
- Write short sentences that are crisp and concise

Changes reflect a more imperative style:
- prompts present commands instead of questions which look like things to do rather than decisions to take
- impersonal approach ("your" / "my" is removed from the text)

### New onboarding process:
```
-  Select language + test runner variant
   - JavaScript / default 
   - TypeScript / default 
   - JavaScript / Mocha 
   - JavaScript / CucumberJS  
- Select target browsers
- Enter source folder where test files are stored (test)
- Enter the base_url of the project (http://localhost)
- Select where to run Nightwatch tests (Use arrow keys)
  -  On localhost 
  - On a remote/cloud service 
  - Both  
- Allow Nightwatch to collect completely anonymous usage metrics? (y/N) 
-  Setup testing on Mobile devices as well? 
```
### Other changes:
- refactored template tests
- refactored tests to be compatible with Mocha

The only prompt which I am not very sure of is "Select where to run Nightwatch tests"; to users who aren't familiar with Selenium or cloud testing services this prompt will most likely be confusing. We should probably change it to be similar to the one for mobile testing setup, e.g.:
```
- Setup Nightwatch to connect to a remote testing service?
   - No, skip for now (default)
   - Yes    
```