### PR TITLE
change @nightwatch/setup-tools to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
-        "@nightwatch/setup-tools": "^3.3.1",
+        "@nightwatch/setup-tools": "latest",
         "ansi-colors": "^4.1.3",
         "axios": "^0.27.2",
         "inquirer": "^8.2.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@nightwatch/setup-tools": "^3.3.1",
+    "@nightwatch/setup-tools": "latest",
     "ansi-colors": "^4.1.3",
     "axios": "^0.27.2",
     "inquirer": "^8.2.4",


### PR DESCRIPTION
Attempting to fix issue #97, wanted to know if this would fix the problem with @nightwatch/setup-tools having a hard dependency on it. When npm install is ran, it should get the latest version of @nightwatch/setup-tools. Let me know if this is correct or if it doesn't fix the problem. 